### PR TITLE
Force maya to stick the deformer node at the head of the chain

### DIFF
--- a/Maya/MEL/ExocortexAlembic/_attach.py
+++ b/Maya/MEL/ExocortexAlembic/_attach.py
@@ -51,7 +51,7 @@ def attachPolyMesh(name, identifier, jobInfo, isConstant=False):
 		return
 
 	# create deformer, and attach time and file
-	newDform = cmds.deformer(name, type="ExocortexAlembicPolyMeshDeform")[0]
+	newDform = cmds.deformer(name, type="ExocortexAlembicPolyMeshDeform", before=True)[0]
 	cmds.setAttr(newDform+".identifier", identifier, type="string")
 	attachTimeAndFile(newDform, jobInfo, isConstant)
 
@@ -91,7 +91,7 @@ def attachCurves(name, identifier, jobInfo, isConstant=False):
 		return
 
 	# create deformer, and attach time and file
-	newDform = cmds.deformer(name, type="ExocortexAlembicCurvesDeform")[0]
+	newDform = cmds.deformer(name, type="ExocortexAlembicCurvesDeform", before=True)[0]
 	cmds.setAttr(newDform+".identifier", identifier, type="string")
 	attachTimeAndFile(newDform, jobInfo, isConstant)
 


### PR DESCRIPTION
to prevent a new "...ShapeDeformed" shape from being created.

Example use case: reference a shaded asset containing sphereShape (with various renderer-specific attributes tweaked) and attach an alembic.
Bad behaviour: before this patch, a new shape named sphereShapeDeformed was created. This shape does not have any of the renderer-specific attributes we painstakingly added to the shaded asset shape.
New behaviour: with before=True, a new shape named sphereShapeOrig is created. The referenced shape is deformed and maintains all of its attributes.