### PR TITLE
Can now reattach Alembics to referenced geometry in Maya

### DIFF
--- a/Maya/AlembicImport.cpp
+++ b/Maya/AlembicImport.cpp
@@ -164,7 +164,7 @@ MStatus AlembicImportCommand::importSingleJob(const MString& job, int jobNumber)
     MDagPath dagPath;
     MItDag().getPath(dagPath);
     SceneNodeAppPtr appRoot = buildMayaSceneGraph(
-        dagPath, SearchReplace::createReplacer(), fileTimeCtrl);
+        dagPath, SearchReplace::createReplacer(), fileTimeCtrl, true);
     if (!AttachSceneFile(fileRoot, appRoot, jobParser, &pBar)) {
       delRefArchive(jobParser.filename);
       return MS::kFailure;

--- a/Maya/sceneGraph.h
+++ b/Maya/sceneGraph.h
@@ -46,9 +46,11 @@ class SceneNodeMaya : public SceneNodeApp {
  public:
   SceneNodeMaya(const AlembicFileAndTimeControlPtr alembicFileAndTimeControl =
                     AlembicFileAndTimeControlPtr())
-      : fileAndTime(alembicFileAndTimeControl), useMultiFile(false)
+      : fileAndTime(alembicFileAndTimeControl), useMultiFile(false), connectTo("")
   {
   }
+
+  MString connectTo;
 
   virtual bool replaceData(SceneNodeAlembicPtr fileNode,
                            const IJobStringParser& jobParams,
@@ -67,6 +69,7 @@ class SceneNodeMaya : public SceneNodeApp {
 SceneNodeAppPtr buildMayaSceneGraph(
     const MDagPath& dagPath, const SearchReplace::ReplacePtr& replacer,
     const AlembicFileAndTimeControlPtr alembicFileAndTimeControl =
-        AlembicFileAndTimeControlPtr());
+        AlembicFileAndTimeControlPtr(),
+    bool allowDeformedByUs = false);
 
 #endif


### PR DESCRIPTION
This works by allowing the addition of intermediate nodes to the internal representation of the Maya scene graph when an associated Deformed Shape node is found that has been deformed by an `ExocortexAlembicPolyMeshDeform`. This is done for attachments only.
These intermediate nodes flag to the attachment code that it should connect to the Deformed node instead of the shape node, using a new `connectTo` attribute on `SceneNodeMaya`.

Fixes #43