### PR TITLE
Attribute caching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,9 +48,9 @@ endif()
 
 if( MSVC9 )
 	SET( PROJECT_NAME "${PROJECT_NAME}_2008" )
-elseif( MSVC10 ) 
+elseif( MSVC10 )
 	SET( PROJECT_NAME "${PROJECT_NAME}_2010" )
-elseif( MSVC11 ) 
+elseif( MSVC11 )
 	SET( PROJECT_NAME "${PROJECT_NAME}_2012" )
 endif()
 
@@ -81,7 +81,7 @@ endif()
 # Configuration
 SET( crate_MAJOR_VERSION "1" )
 SET( crate_MINOR_VERSION "1" ) 
-SET( crate_BUILD_VERSION "145")
+SET( crate_BUILD_VERSION "151")
 SET( crate_VERSION "${crate_MAJOR_VERSION}.${crate_MINOR_VERSION}" )
 SET( crate_FULLVERSION "${crate_MAJOR_VERSION}.${crate_MINOR_VERSION}.${crate_BUILD_VERSION}" )
 
@@ -309,15 +309,12 @@ ENDIF()
 # maya plugin
 # guide to maya compiler versions: http://around-the-corner.typepad.com/adn/2012/06/maya-compiler-versions.html
 IF(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Maya/CMakeLists.txt")
-	if( NOT MSVC10 AND NOT MSVC11) 
-		ADD_SUBDIRECTORY ( "${CMAKE_CURRENT_SOURCE_DIR}/Maya/2011" "${CMAKE_CURRENT_BINARY_DIR}/ExocortexAlembicMaya/2011" )
-		ADD_SUBDIRECTORY ( "${CMAKE_CURRENT_SOURCE_DIR}/Maya/2012" "${CMAKE_CURRENT_BINARY_DIR}/ExocortexAlembicMaya/2012" )
-		ADD_SUBDIRECTORY ( "${CMAKE_CURRENT_SOURCE_DIR}/Maya/2013" "${CMAKE_CURRENT_BINARY_DIR}/ExocortexAlembicMaya/2013" )
-		#ADD_SUBDIRECTORY ( "${CMAKE_CURRENT_SOURCE_DIR}/Maya/2013.5" "${CMAKE_CURRENT_BINARY_DIR}/ExocortexAlembicMaya/2013.5" )
+  if( MSVC10 )
 		ADD_SUBDIRECTORY ( "${CMAKE_CURRENT_SOURCE_DIR}/Maya/2014" "${CMAKE_CURRENT_BINARY_DIR}/ExocortexAlembicMaya/2014" )
+  elseif( MSVC11 )
 		ADD_SUBDIRECTORY ( "${CMAKE_CURRENT_SOURCE_DIR}/Maya/2015" "${CMAKE_CURRENT_BINARY_DIR}/ExocortexAlembicMaya/2015" )
 		ADD_SUBDIRECTORY ( "${CMAKE_CURRENT_SOURCE_DIR}/Maya/2016" "${CMAKE_CURRENT_BINARY_DIR}/ExocortexAlembicMaya/2016" )
-	endif()
+  endif()
 ENDIF()
 
 # houdini plugin

--- a/ExocortexCMakeShared.txt
+++ b/ExocortexCMakeShared.txt
@@ -19,14 +19,14 @@ function(setup_cpu_name)
 endfunction()
 
 
-function(setup_precompiled_header LocalSourceDir)
+function(setup_precompiled_header LocalSourceDir Sources)
 	if (MSVC)
 		set( LOCAL_SOURCE_DIR ${LocalSourceDir} )
 		
-		list( REMOVE_ITEM ARGN "${LOCAL_SOURCE_DIR}/stdafx.cpp" )
-		list( REMOVE_ITEM ARGN "${LOCAL_SOURCE_DIR}/stdafx.h" )
+		list( REMOVE_ITEM ${${Sources}} "${LOCAL_SOURCE_DIR}/stdafx.cpp" )
+		list( REMOVE_ITEM ${${Sources}} "${LOCAL_SOURCE_DIR}/stdafx.h" )
 
-		foreach( src_file ${ARGN} )
+		foreach( src_file ${${Sources}} )
 			set_source_files_properties(
 				${src_file}
 				PROPERTIES
@@ -37,6 +37,7 @@ function(setup_precompiled_header LocalSourceDir)
 			PROPERTIES
 			COMPILE_FLAGS "/Ycstdafx.h"
 			)
+    list(APPEND ${Sources} ${LOCAL_SOURCE_DIR}/stdafx.cpp)
 	endif()
 endfunction()
 

--- a/Maya/AlembicCamera.cpp
+++ b/Maya/AlembicCamera.cpp
@@ -18,7 +18,8 @@ AlembicCamera::~AlembicCamera()
   mSchema.reset();
 }
 
-MStatus AlembicCamera::Save(double time)
+MStatus AlembicCamera::Save(double time, unsigned int timeIndex,
+    bool isFirstFrame)
 {
   ESS_PROFILE_SCOPE("AlembicCamera::Save");
   // access the camera
@@ -26,6 +27,22 @@ MStatus AlembicCamera::Save(double time)
 
   // save the metadata
   SaveMetaData(this);
+
+  if (isFirstFrame) {
+    Abc::OCompoundProperty cp;
+    Abc::OCompoundProperty up;
+    if (AttributesWriter::hasAnyAttr(node, *GetJob())) {
+      cp = mSchema.getArbGeomParams();
+      up = mSchema.getUserProperties();
+    }
+
+    mAttrs = AttributesWriterPtr(
+        new AttributesWriter(cp, up, GetMyParent(), node, timeIndex, *GetJob())
+        );
+  }
+  else {
+    mAttrs->write();
+  }
 
   // bake in the device aspect ratio since other programs do not support it (see
   // the article "Maya to Softimage: Camera Interoperability")

--- a/Maya/AlembicCamera.h
+++ b/Maya/AlembicCamera.h
@@ -2,12 +2,14 @@
 #define _ALEMBIC_CAMERA_H_
 
 #include "AlembicObject.h"
+#include "AttributesWriter.h"
 
 class AlembicCamera : public AlembicObject {
  private:
   AbcG::OCamera mObject;
   AbcG::OCameraSchema mSchema;
   AbcG::CameraSample mSample;
+  AttributesWriterPtr mAttrs;
 
  public:
   AlembicCamera(SceneNodePtr eNode, AlembicWriteJob* in_Job,
@@ -16,7 +18,8 @@ class AlembicCamera : public AlembicObject {
 
   virtual Abc::OObject GetObject() { return mObject; }
   virtual Abc::OCompoundProperty GetCompound() { return mSchema; }
-  virtual MStatus Save(double time);
+  virtual MStatus Save(double time, unsigned int timeIndex,
+      bool isFirstFrame);
 };
 
 class AlembicCameraNode : public AlembicObjectNode {

--- a/Maya/AlembicCamera.h
+++ b/Maya/AlembicCamera.h
@@ -33,6 +33,12 @@ class AlembicCameraNode : public AlembicObjectNode {
   static void* creator() { return (new AlembicCameraNode()); }
   static MStatus initialize();
 
+  bool setInternalValueInContext(const MPlug & plug,
+      const MDataHandle & dataHandle,
+      MDGContext & ctx);
+  MStatus setDependentsDirty(const MPlug &plugBeingDirtied,
+      MPlugArray &affectedPlugs);
+
  private:
   // input attributes
   static MObject mTimeAttr;
@@ -40,6 +46,8 @@ class AlembicCameraNode : public AlembicObjectNode {
   static MObject mIdentifierAttr;
   MString mFileName;
   MString mIdentifier;
+  MPlugArray mGeomParamPlugs;
+  MPlugArray mUserAttrPlugs;
   AbcG::ICameraSchema mSchema;
 
   // output attributes
@@ -54,6 +62,9 @@ class AlembicCameraNode : public AlembicObjectNode {
   static MObject mOutFarClippingAttr;
   static MObject mOutFStopAttr;
   static MObject mOutShutterAngleAttr;
+
+  static MObject mGeomParamsList;
+  static MObject mUserAttrsList;
 };
 
 #endif

--- a/Maya/AlembicCurves.cpp
+++ b/Maya/AlembicCurves.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 
 #include "AlembicCurves.h"
+#include "AttributesReading.h"
 #include "MetaData.h"
 
 #include <maya/MArrayDataBuilder.h>
@@ -290,6 +291,9 @@ MObject AlembicCurvesNode::mFileNameAttr;
 MObject AlembicCurvesNode::mIdentifierAttr;
 MObject AlembicCurvesNode::mOutGeometryAttr;
 
+MObject AlembicCurvesNode::mGeomParamsList;
+MObject AlembicCurvesNode::mUserAttrsList;
+
 MStatus AlembicCurvesNode::initialize()
 {
   MStatus status;
@@ -332,6 +336,24 @@ MStatus AlembicCurvesNode::initialize()
   status = tAttr.setKeyable(false);
   status = tAttr.setHidden(false);
   status = addAttribute(mOutGeometryAttr);
+
+  // output for list of ArbGeomParams
+  mGeomParamsList = tAttr.create("ExocortexAlembic_GeomParams", "exo_gp",
+      MFnData::kString, emptyStringObject);
+  status = tAttr.setStorable(true);
+  status = tAttr.setKeyable(false);
+  status = tAttr.setHidden(false);
+  status = tAttr.setInternal(true);
+  status = addAttribute(mGeomParamsList);
+
+  // output for list of UserAttributes
+  mUserAttrsList = tAttr.create("ExocortexAlembic_UserAttributes", "exo_ua",
+      MFnData::kString, emptyStringObject);
+  status = tAttr.setStorable(true);
+  status = tAttr.setKeyable(false);
+  status = tAttr.setHidden(false);
+  status = tAttr.setInternal(true);
+  status = addAttribute(mUserAttrsList);
 
   // create a mapping
   status = attributeAffects(mTimeAttr, mOutGeometryAttr);
@@ -382,6 +404,25 @@ MStatus AlembicCurvesNode::compute(const MPlug &plug, MDataBlock &dataBlock)
 
   if (!mSchema.valid()) {
     return MStatus::kFailure;
+  }
+
+  {
+    ESS_PROFILE_SCOPE("AlembicCurvesNode::compute readProps");
+    Alembic::Abc::ICompoundProperty arbProp = mSchema.getArbGeomParams();
+    Alembic::Abc::ICompoundProperty userProp = mSchema.getUserProperties();
+    readProps(inputTime, arbProp, dataBlock, thisMObject());
+    readProps(inputTime, userProp, dataBlock, thisMObject());
+
+    // Set all plugs as clean
+    // Even if one of them failed to get set,
+    // trying again in this frame isn't going to help
+    for (unsigned int i = 0; i < mGeomParamPlugs.length(); i++) {
+      dataBlock.outputValue(mGeomParamPlugs[i]).setClean();
+    }
+
+    for (unsigned int i = 0; i < mUserAttrPlugs.length(); i++) {
+      dataBlock.outputValue(mUserAttrPlugs[i]).setClean();
+    }
   }
 
   // get the sample
@@ -491,6 +532,41 @@ MStatus AlembicCurvesNode::compute(const MPlug &plug, MDataBlock &dataBlock)
   return MStatus::kSuccess;
 }
 
+// Cache the plug arrays for use in setDependentsDirty
+bool AlembicCurvesNode::setInternalValueInContext(const MPlug & plug,
+    const MDataHandle & dataHandle,
+    MDGContext &)
+{
+  if (plug == mGeomParamsList) {
+    MString geomParamsStr = dataHandle.asString();
+    getPlugArrayFromAttrList(geomParamsStr, thisMObject(), mGeomParamPlugs);
+  }
+  else if (plug == mUserAttrsList) {
+    MString userAttrsStr = dataHandle.asString();
+    getPlugArrayFromAttrList(userAttrsStr, thisMObject(), mUserAttrPlugs);
+  }
+
+  return false;
+}
+
+MStatus AlembicCurvesNode::setDependentsDirty(const MPlug &plugBeingDirtied,
+    MPlugArray &affectedPlugs)
+{
+  if (plugBeingDirtied == mFileNameAttr || plugBeingDirtied == mIdentifierAttr
+      || plugBeingDirtied == mTimeAttr) {
+
+    for (unsigned int i = 0; i < mGeomParamPlugs.length(); i++) {
+      affectedPlugs.append(mGeomParamPlugs[i]);
+    }
+
+    for (unsigned int i = 0; i < mUserAttrPlugs.length(); i++) {
+      affectedPlugs.append(mUserAttrPlugs[i]);
+    }
+  }
+
+  return MStatus::kSuccess;
+}
+
 void AlembicCurvesDeformNode::PreDestruction()
 {
   mSchema.reset();
@@ -502,6 +578,9 @@ AlembicCurvesDeformNode::~AlembicCurvesDeformNode() { PreDestruction(); }
 MObject AlembicCurvesDeformNode::mTimeAttr;
 MObject AlembicCurvesDeformNode::mFileNameAttr;
 MObject AlembicCurvesDeformNode::mIdentifierAttr;
+
+MObject AlembicCurvesDeformNode::mGeomParamsList;
+MObject AlembicCurvesDeformNode::mUserAttrsList;
 
 MStatus AlembicCurvesDeformNode::initialize()
 {
@@ -534,6 +613,24 @@ MStatus AlembicCurvesDeformNode::initialize()
   status = tAttr.setStorable(true);
   status = tAttr.setKeyable(false);
   status = addAttribute(mIdentifierAttr);
+
+  // output for list of ArbGeomParams
+  mGeomParamsList = tAttr.create("ExocortexAlembic_GeomParams", "exo_gp",
+      MFnData::kString, emptyStringObject);
+  status = tAttr.setStorable(true);
+  status = tAttr.setKeyable(false);
+  status = tAttr.setHidden(false);
+  status = tAttr.setInternal(true);
+  status = addAttribute(mGeomParamsList);
+
+  // output for list of UserAttributes
+  mUserAttrsList = tAttr.create("ExocortexAlembic_UserAttributes", "exo_ua",
+      MFnData::kString, emptyStringObject);
+  status = tAttr.setStorable(true);
+  status = tAttr.setKeyable(false);
+  status = tAttr.setHidden(false);
+  status = tAttr.setInternal(true);
+  status = addAttribute(mUserAttrsList);
 
   // create a mapping
   status = attributeAffects(mTimeAttr, outputGeom);
@@ -589,6 +686,25 @@ MStatus AlembicCurvesDeformNode::deform(MDataBlock &dataBlock,
 
   if (!mSchema.valid()) {
     return MStatus::kFailure;
+  }
+
+  {
+    ESS_PROFILE_SCOPE("AlembicCurvesDeformNode::deform readProps");
+    Alembic::Abc::ICompoundProperty arbProp = mSchema.getArbGeomParams();
+    Alembic::Abc::ICompoundProperty userProp = mSchema.getUserProperties();
+    readProps(inputTime, arbProp, dataBlock, thisMObject());
+    readProps(inputTime, userProp, dataBlock, thisMObject());
+
+    // Set all plugs as clean
+    // Even if one of them failed to get set,
+    // trying again in this frame isn't going to help
+    for (unsigned int i = 0; i < mGeomParamPlugs.length(); i++) {
+      dataBlock.outputValue(mGeomParamPlugs[i]).setClean();
+    }
+
+    for (unsigned int i = 0; i < mUserAttrPlugs.length(); i++) {
+      dataBlock.outputValue(mUserAttrPlugs[i]).setClean();
+    }
   }
 
   // get the sample
@@ -658,6 +774,41 @@ MStatus AlembicCurvesDeformNode::deform(MDataBlock &dataBlock,
     }
     iter.setPosition(abcPos);
   }
+  return MStatus::kSuccess;
+}
+
+// Cache the plug arrays for use in setDependentsDirty
+bool AlembicCurvesDeformNode::setInternalValueInContext(const MPlug & plug,
+    const MDataHandle & dataHandle,
+    MDGContext &)
+{
+  if (plug == mGeomParamsList) {
+    MString geomParamsStr = dataHandle.asString();
+    getPlugArrayFromAttrList(geomParamsStr, thisMObject(), mGeomParamPlugs);
+  }
+  else if (plug == mUserAttrsList) {
+    MString userAttrsStr = dataHandle.asString();
+    getPlugArrayFromAttrList(userAttrsStr, thisMObject(), mUserAttrPlugs);
+  }
+
+  return false;
+}
+
+MStatus AlembicCurvesDeformNode::setDependentsDirty(const MPlug &plugBeingDirtied,
+    MPlugArray &affectedPlugs)
+{
+  if (plugBeingDirtied == mFileNameAttr || plugBeingDirtied == mIdentifierAttr
+      || plugBeingDirtied == mTimeAttr) {
+
+    for (unsigned int i = 0; i < mGeomParamPlugs.length(); i++) {
+      affectedPlugs.append(mGeomParamPlugs[i]);
+    }
+
+    for (unsigned int i = 0; i < mUserAttrPlugs.length(); i++) {
+      affectedPlugs.append(mUserAttrPlugs[i]);
+    }
+  }
+
   return MStatus::kSuccess;
 }
 

--- a/Maya/AlembicCurves.h
+++ b/Maya/AlembicCurves.h
@@ -109,6 +109,12 @@ class AlembicCurvesNode : public AlembicObjectNode {
   static void *creator() { return (new AlembicCurvesNode()); }
   static MStatus initialize();
 
+  bool setInternalValueInContext(const MPlug & plug,
+      const MDataHandle & dataHandle,
+      MDGContext & ctx);
+  MStatus setDependentsDirty(const MPlug &plugBeingDirtied,
+      MPlugArray &affectedPlugs);
+
  private:
   // input attributes
   static MObject mTimeAttr;
@@ -116,11 +122,16 @@ class AlembicCurvesNode : public AlembicObjectNode {
   static MObject mIdentifierAttr;
   MString mFileName;
   MString mIdentifier;
+  MPlugArray mGeomParamPlugs;
+  MPlugArray mUserAttrPlugs;
   AbcG::ICurves mObj;
   AbcG::ICurvesSchema mSchema;
 
   // output attributes
   static MObject mOutGeometryAttr;
+
+  static MObject mGeomParamsList;
+  static MObject mUserAttrsList;
 
   // members
   SampleInfo mLastSampleInfo;
@@ -138,6 +149,12 @@ class AlembicCurvesDeformNode : public AlembicObjectDeformNode {
   static void *creator() { return (new AlembicCurvesDeformNode()); }
   static MStatus initialize();
 
+  bool setInternalValueInContext(const MPlug & plug,
+      const MDataHandle & dataHandle,
+      MDGContext & ctx);
+  MStatus setDependentsDirty(const MPlug &plugBeingDirtied,
+      MPlugArray &affectedPlugs);
+
  private:
   // input attributes
   static MObject mTimeAttr;
@@ -145,7 +162,13 @@ class AlembicCurvesDeformNode : public AlembicObjectDeformNode {
   static MObject mIdentifierAttr;
   MString mFileName;
   MString mIdentifier;
+  MPlugArray mGeomParamPlugs;
+  MPlugArray mUserAttrPlugs;
   AbcG::ICurvesSchema mSchema;
+
+  // output attributes
+  static MObject mGeomParamsList;
+  static MObject mUserAttrsList;
 
   // members
   SampleInfo mLastSampleInfo;

--- a/Maya/AlembicCurves.h
+++ b/Maya/AlembicCurves.h
@@ -4,6 +4,7 @@
 #include <maya/MFnNurbsCurve.h>
 #include <maya/MUint64Array.h>
 #include "AlembicObject.h"
+#include "AttributesWriter.h"
 
 //-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -72,6 +73,8 @@ class AlembicCurves : public AlembicObject {
   AbcG::OCurvesSchema mSchema;
   AbcG::OCurvesSchema::Sample mSample;
 
+  AttributesWriterPtr mAttrs;
+
   std::vector<Abc::V3f> mPosVec;
   std::vector<AbcA::int32_t> mNbVertices;
   std::vector<float> mRadiusVec;
@@ -91,7 +94,8 @@ class AlembicCurves : public AlembicObject {
 
   virtual Abc::OObject GetObject() { return mObject; }
   virtual Abc::OCompoundProperty GetCompound() { return mSchema; }
-  virtual MStatus Save(double time);
+  virtual MStatus Save(double time, unsigned int timeIndex,
+      bool isFirstFrame);
 };
 
 class AlembicCurvesNode : public AlembicObjectNode {

--- a/Maya/AlembicHair.cpp
+++ b/Maya/AlembicHair.cpp
@@ -24,7 +24,8 @@ AlembicHair::~AlembicHair()
   mSchema.reset();
 }
 
-MStatus AlembicHair::Save(double time)
+MStatus AlembicHair::Save(double time, unsigned int timeIndex,
+    bool isFirstFrame)
 {
   ESS_PROFILE_SCOPE("AlembicHair::Save");
   MStatus status;
@@ -34,6 +35,23 @@ MStatus AlembicHair::Save(double time)
 
   // save the metadata
   SaveMetaData(this);
+
+  // save the attributes
+  if (isFirstFrame) {
+    Abc::OCompoundProperty cp;
+    Abc::OCompoundProperty up;
+    if (AttributesWriter::hasAnyAttr(node, *GetJob())) {
+      cp = mSchema.getArbGeomParams();
+      up = mSchema.getUserProperties();
+    }
+
+    mAttrs = AttributesWriterPtr(
+        new AttributesWriter(cp, up, GetMyParent(), node, timeIndex, *GetJob())
+        );
+  }
+  else {
+    mAttrs->write();
+  }
 
   // prepare the bounding box
   Abc::Box3d bbox;

--- a/Maya/AlembicHair.cpp
+++ b/Maya/AlembicHair.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 
 #include "AlembicHair.h"
+#include "AttributesReading.h"
 #include "MetaData.h"
 
 AlembicHair::AlembicHair(SceneNodePtr eNode, AlembicWriteJob *in_Job,

--- a/Maya/AlembicHair.h
+++ b/Maya/AlembicHair.h
@@ -4,12 +4,15 @@
 #include <maya/MFnPfxGeometry.h>
 #include <maya/MUint64Array.h>
 #include "AlembicObject.h"
+#include "AttributesWriter.h"
 
 class AlembicHair : public AlembicObject {
  private:
   AbcG::OCurves mObject;
   AbcG::OCurvesSchema mSchema;
   AbcG::OCurvesSchema::Sample mSample;
+
+  AttributesWriterPtr mAttrs;
 
   std::vector<Abc::V3f> mPosVec;
   std::vector<AbcA::int32_t> mNbVertices;
@@ -30,7 +33,8 @@ class AlembicHair : public AlembicObject {
 
   virtual Abc::OObject GetObject() { return mObject; }
   virtual Abc::OCompoundProperty GetCompound() { return mSchema; }
-  virtual MStatus Save(double time);
+  virtual MStatus Save(double time, unsigned int timeIndex,
+      bool isFirstFrame);
 };
 
 /*

--- a/Maya/AlembicObject.h
+++ b/Maya/AlembicObject.h
@@ -38,7 +38,8 @@ class AlembicObject {
   int GetNumSamples() { return mNumSamples; }
   MString GetUniqueName(const MString& in_Name);
 
-  virtual MStatus Save(double time) = 0;
+  virtual MStatus Save(double time, unsigned int timeIndex,
+      bool isFirstFrame) = 0;
 };
 
 class AlembicObjectNode : public MPxNode {

--- a/Maya/AlembicPoints.cpp
+++ b/Maya/AlembicPoints.cpp
@@ -146,7 +146,8 @@ AlembicPoints::~AlembicPoints()
   mSchema.reset();
 }
 
-MStatus AlembicPoints::Save(double time)
+MStatus AlembicPoints::Save(double time, unsigned int timeIndex,
+    bool isFirstFrame)
 {
   ESS_PROFILE_SCOPE("AlembicPoints::Save");
   // access the geometry
@@ -154,6 +155,23 @@ MStatus AlembicPoints::Save(double time)
 
   // save the metadata
   SaveMetaData(this);
+
+  // save the attributes
+  if (isFirstFrame) {
+    Abc::OCompoundProperty cp;
+    Abc::OCompoundProperty up;
+    if (AttributesWriter::hasAnyAttr(node, *GetJob())) {
+      cp = mSchema.getArbGeomParams();
+      up = mSchema.getUserProperties();
+    }
+
+    mAttrs = AttributesWriterPtr(
+        new AttributesWriter(cp, up, GetMyParent(), node, timeIndex, *GetJob())
+        );
+  }
+  else {
+    mAttrs->write();
+  }
 
   // prepare the bounding box
   Abc::Box3d bbox;

--- a/Maya/AlembicPoints.h
+++ b/Maya/AlembicPoints.h
@@ -116,6 +116,12 @@ class AlembicPointsNode : public AlembicObjectEmitterNode {
   static void *creator() { return (new AlembicPointsNode()); }
   static MStatus initialize();
 
+  bool setInternalValueInContext(const MPlug & plug,
+      const MDataHandle & dataHandle,
+      MDGContext & ctx);
+  MStatus setDependentsDirty(const MPlug &plugBeingDirtied,
+      MPlugArray &affectedPlugs);
+
  private:
   // input attributes
   static MObject mTimeAttr;
@@ -123,9 +129,15 @@ class AlembicPointsNode : public AlembicObjectEmitterNode {
   static MObject mIdentifierAttr;
   MString mFileName;
   MString mIdentifier;
+  MPlugArray mGeomParamPlugs;
+  MPlugArray mUserAttrPlugs;
   AbcG::IPointsSchema mSchema;
   AbcG::IPoints obj;
   AlembicPointsNodeListIter listPosition;
+
+  // output attributes
+  static MObject mGeomParamsList;
+  static MObject mUserAttrsList;
 
   MStatus init(const MString &filename, const MString &identifier);
   MStatus initPerParticles(const MString &partName);

--- a/Maya/AlembicPoints.h
+++ b/Maya/AlembicPoints.h
@@ -5,6 +5,7 @@
 #include <maya/MFnParticleSystem.h>
 #include <list>
 #include "AlembicObject.h"
+#include "AttributesWriter.h"
 
 class AlembicPoints : public AlembicObject {
  private:
@@ -14,6 +15,8 @@ class AlembicPoints : public AlembicObject {
   AbcG::OPoints mObject;
   AbcG::OPointsSchema mSchema;
   AbcG::OPointsSchema::Sample mSample;
+
+  AttributesWriterPtr mAttrs;
 
   Abc::OFloatArrayProperty mAgeProperty;
   Abc::OFloatArrayProperty mMassProperty;
@@ -43,7 +46,8 @@ class AlembicPoints : public AlembicObject {
 
   virtual Abc::OObject GetObject() { return mObject; }
   virtual Abc::OCompoundProperty GetCompound() { return mSchema; }
-  virtual MStatus Save(double time);
+  virtual MStatus Save(double time, unsigned int timeIndex,
+      bool isFirstFrame);
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Maya/AlembicPolyMesh.h
+++ b/Maya/AlembicPolyMesh.h
@@ -3,6 +3,7 @@
 
 #include <maya/MFnMesh.h>
 #include "AlembicObject.h"
+#include "AttributesWriter.h"
 
 class AlembicPolyMesh : public AlembicObject {
  private:
@@ -10,6 +11,8 @@ class AlembicPolyMesh : public AlembicObject {
   AbcG::OPolyMeshSchema mSchema;
   int mPointCountLastFrame;
   std::vector<unsigned int> mSampleLookup;
+
+  AttributesWriterPtr mAttrs;
 
   AbcG::OPolyMeshSchema::Sample mSample;
   std::vector<AbcG::OV2fGeomParam> mUvParams;
@@ -21,7 +24,8 @@ class AlembicPolyMesh : public AlembicObject {
 
   virtual Abc::OObject GetObject() { return mObject; }
   virtual Abc::OCompoundProperty GetCompound() { return mSchema; }
-  virtual MStatus Save(double time);
+  virtual MStatus Save(double time, unsigned int timeIndex,
+      bool isFirstFrame);
 };
 
 class AlembicPolyMeshNode : public AlembicObjectNode {

--- a/Maya/AlembicPolyMesh.h
+++ b/Maya/AlembicPolyMesh.h
@@ -39,6 +39,12 @@ class AlembicPolyMeshNode : public AlembicObjectNode {
   static void* creator() { return (new AlembicPolyMeshNode()); }
   static MStatus initialize();
 
+  bool setInternalValueInContext(const MPlug & plug,
+      const MDataHandle & dataHandle,
+      MDGContext & ctx);
+  MStatus setDependentsDirty(const MPlug &plugBeingDirtied,
+      MPlugArray &affectedPlugs);
+
  private:
   // input attributes
   static MObject mTimeAttr;
@@ -50,6 +56,8 @@ class AlembicPolyMeshNode : public AlembicObjectNode {
   MString mIdentifier;
   MString mUvFileName;
   MString mUvIdentifier;
+  MPlugArray mGeomParamPlugs;
+  MPlugArray mUserAttrPlugs;
   Abc::IObject mObj;
   AbcG::IPolyMeshSchema mSchema;
   AbcG::IPolyMeshSchema mUvSchema;
@@ -60,6 +68,9 @@ class AlembicPolyMeshNode : public AlembicObjectNode {
 
   // output attributes
   static MObject mOutGeometryAttr;
+
+  static MObject mGeomParamsList;
+  static MObject mUserAttrsList;
 
   // members
   SampleInfo mLastSampleInfo;
@@ -85,6 +96,12 @@ class AlembicPolyMeshDeformNode : public AlembicObjectDeformNode {
   static void* creator() { return (new AlembicPolyMeshDeformNode()); }
   static MStatus initialize();
 
+  bool setInternalValueInContext(const MPlug & plug,
+      const MDataHandle & dataHandle,
+      MDGContext & ctx);
+  MStatus setDependentsDirty(const MPlug &plugBeingDirtied,
+      MPlugArray &affectedPlugs);
+
  private:
   // input attributes
   static MObject mTimeAttr;
@@ -92,9 +109,15 @@ class AlembicPolyMeshDeformNode : public AlembicObjectDeformNode {
   static MObject mIdentifierAttr;
   MString mFileName;
   MString mIdentifier;
+  MPlugArray mGeomParamPlugs;
+  MPlugArray mUserAttrPlugs;
   Abc::IObject mObj;
   AbcG::IPolyMeshSchema mSchema;
   bool mDynamicTopology;
+
+  // output attributes
+  static MObject mGeomParamsList;
+  static MObject mUserAttrsList;
 
   // members
   SampleInfo mLastSampleInfo;

--- a/Maya/AlembicSubD.cpp
+++ b/Maya/AlembicSubD.cpp
@@ -18,7 +18,8 @@ AlembicSubD::~AlembicSubD()
   mSchema.reset();
 }
 
-MStatus AlembicSubD::Save(double time)
+MStatus AlembicSubD::Save(double time, unsigned int timeIndex,
+    bool isFirstFrame)
 {
   ESS_PROFILE_SCOPE("AlembicSubD::Save");
   // access the geometry
@@ -26,6 +27,23 @@ MStatus AlembicSubD::Save(double time)
 
   // save the metadata
   SaveMetaData(this);
+
+  // save the attributes
+  if (isFirstFrame) {
+    Abc::OCompoundProperty cp;
+    Abc::OCompoundProperty up;
+    if (AttributesWriter::hasAnyAttr(node, *GetJob())) {
+      cp = mSchema.getArbGeomParams();
+      up = mSchema.getUserProperties();
+    }
+
+    mAttrs = AttributesWriterPtr(
+        new AttributesWriter(cp, up, GetMyParent(), node, timeIndex, *GetJob())
+        );
+  }
+  else {
+    mAttrs->write();
+  }
 
   // prepare the bounding box
   Abc::Box3d bbox;

--- a/Maya/AlembicSubD.cpp
+++ b/Maya/AlembicSubD.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 
 #include "AlembicSubD.h"
+#include "AttributesReading.h"
 #include "MetaData.h"
 
 AlembicSubD::AlembicSubD(SceneNodePtr eNode, AlembicWriteJob* in_Job,
@@ -246,6 +247,9 @@ MObject AlembicSubDNode::mUvsAttr;
 MObject AlembicSubDNode::mOutGeometryAttr;
 MObject AlembicSubDNode::mOutDispResolutionAttr;
 
+MObject AlembicSubDNode::mGeomParamsList;
+MObject AlembicSubDNode::mUserAttrsList;
+
 MStatus AlembicSubDNode::initialize()
 {
   MStatus status;
@@ -301,6 +305,24 @@ MStatus AlembicSubDNode::initialize()
   status = nAttr.setHidden(false);
   status = addAttribute(mOutDispResolutionAttr);
 
+  // output for list of ArbGeomParams
+  mGeomParamsList = tAttr.create("ExocortexAlembic_GeomParams", "exo_gp",
+      MFnData::kString, emptyStringObject);
+  status = tAttr.setStorable(true);
+  status = tAttr.setKeyable(false);
+  status = tAttr.setHidden(false);
+  status = tAttr.setInternal(true);
+  status = addAttribute(mGeomParamsList);
+
+  // output for list of UserAttributes
+  mUserAttrsList = tAttr.create("ExocortexAlembic_UserAttributes", "exo_ua",
+      MFnData::kString, emptyStringObject);
+  status = tAttr.setStorable(true);
+  status = tAttr.setKeyable(false);
+  status = tAttr.setHidden(false);
+  status = tAttr.setInternal(true);
+  status = addAttribute(mUserAttrsList);
+
   // create a mapping
   status = attributeAffects(mTimeAttr, mOutGeometryAttr);
   status = attributeAffects(mFileNameAttr, mOutGeometryAttr);
@@ -354,6 +376,25 @@ MStatus AlembicSubDNode::compute(const MPlug& plug, MDataBlock& dataBlock)
 
   if (!mSchema.valid()) {
     return MStatus::kFailure;
+  }
+
+  {
+    ESS_PROFILE_SCOPE("AlembicSubDNode::compute readProps");
+    Alembic::Abc::ICompoundProperty arbProp = mSchema.getArbGeomParams();
+    Alembic::Abc::ICompoundProperty userProp = mSchema.getUserProperties();
+    readProps(inputTime, arbProp, dataBlock, thisMObject());
+    readProps(inputTime, userProp, dataBlock, thisMObject());
+
+    // Set all plugs as clean
+    // Even if one of them failed to get set,
+    // trying again in this frame isn't going to help
+    for (unsigned int i = 0; i < mGeomParamPlugs.length(); i++) {
+      dataBlock.outputValue(mGeomParamPlugs[i]).setClean();
+    }
+
+    for (unsigned int i = 0; i < mUserAttrPlugs.length(); i++) {
+      dataBlock.outputValue(mUserAttrPlugs[i]).setClean();
+    }
   }
 
   // get the sample
@@ -491,6 +532,41 @@ MStatus AlembicSubDNode::compute(const MPlug& plug, MDataBlock& dataBlock)
   return MStatus::kSuccess;
 }
 
+// Cache the plug arrays for use in setDependentsDirty
+bool AlembicSubDNode::setInternalValueInContext(const MPlug & plug,
+    const MDataHandle & dataHandle,
+    MDGContext &)
+{
+  if (plug == mGeomParamsList) {
+    MString geomParamsStr = dataHandle.asString();
+    getPlugArrayFromAttrList(geomParamsStr, thisMObject(), mGeomParamPlugs);
+  }
+  else if (plug == mUserAttrsList) {
+    MString userAttrsStr = dataHandle.asString();
+    getPlugArrayFromAttrList(userAttrsStr, thisMObject(), mUserAttrPlugs);
+  }
+
+  return false;
+}
+
+MStatus AlembicSubDNode::setDependentsDirty(const MPlug &plugBeingDirtied,
+    MPlugArray &affectedPlugs)
+{
+  if (plugBeingDirtied == mFileNameAttr || plugBeingDirtied == mIdentifierAttr
+      || plugBeingDirtied == mTimeAttr) {
+
+    for (unsigned int i = 0; i < mGeomParamPlugs.length(); i++) {
+      affectedPlugs.append(mGeomParamPlugs[i]);
+    }
+
+    for (unsigned int i = 0; i < mUserAttrPlugs.length(); i++) {
+      affectedPlugs.append(mUserAttrPlugs[i]);
+    }
+  }
+
+  return MStatus::kSuccess;
+}
+
 void AlembicSubDDeformNode::PreDestruction()
 {
   mSchema.reset();
@@ -502,6 +578,9 @@ AlembicSubDDeformNode::~AlembicSubDDeformNode() { PreDestruction(); }
 MObject AlembicSubDDeformNode::mTimeAttr;
 MObject AlembicSubDDeformNode::mFileNameAttr;
 MObject AlembicSubDDeformNode::mIdentifierAttr;
+
+MObject AlembicSubDDeformNode::mGeomParamsList;
+MObject AlembicSubDDeformNode::mUserAttrsList;
 
 MStatus AlembicSubDDeformNode::initialize()
 {
@@ -534,6 +613,24 @@ MStatus AlembicSubDDeformNode::initialize()
   status = tAttr.setStorable(true);
   status = tAttr.setKeyable(false);
   status = addAttribute(mIdentifierAttr);
+
+  // output for list of ArbGeomParams
+  mGeomParamsList = tAttr.create("ExocortexAlembic_GeomParams", "exo_gp",
+      MFnData::kString, emptyStringObject);
+  status = tAttr.setStorable(true);
+  status = tAttr.setKeyable(false);
+  status = tAttr.setHidden(false);
+  status = tAttr.setInternal(true);
+  status = addAttribute(mGeomParamsList);
+
+  // output for list of UserAttributes
+  mUserAttrsList = tAttr.create("ExocortexAlembic_UserAttributes", "exo_ua",
+      MFnData::kString, emptyStringObject);
+  status = tAttr.setStorable(true);
+  status = tAttr.setKeyable(false);
+  status = tAttr.setHidden(false);
+  status = tAttr.setInternal(true);
+  status = addAttribute(mUserAttrsList);
 
   // create a mapping
   status = attributeAffects(mTimeAttr, outputGeom);
@@ -629,6 +726,25 @@ MStatus AlembicSubDDeformNode::deform(MDataBlock& dataBlock, MItGeometry& iter,
     return MStatus::kFailure;
   }
 
+  {
+    ESS_PROFILE_SCOPE("AlembicSubDDeformNode::deform readProps");
+    Alembic::Abc::ICompoundProperty arbProp = mSchema.getArbGeomParams();
+    Alembic::Abc::ICompoundProperty userProp = mSchema.getUserProperties();
+    readProps(inputTime, arbProp, dataBlock, thisMObject());
+    readProps(inputTime, userProp, dataBlock, thisMObject());
+
+    // Set all plugs as clean
+    // Even if one of them failed to get set,
+    // trying again in this frame isn't going to help
+    for (unsigned int i = 0; i < mGeomParamPlugs.length(); i++) {
+      dataBlock.outputValue(mGeomParamPlugs[i]).setClean();
+    }
+
+    for (unsigned int i = 0; i < mUserAttrPlugs.length(); i++) {
+      dataBlock.outputValue(mUserAttrPlugs[i]).setClean();
+    }
+  }
+
   // get the sample
   SampleInfo sampleInfo = getSampleInfo(inputTime, mSchema.getTimeSampling(),
                                         mSchema.getNumSamples());
@@ -700,5 +816,40 @@ MStatus AlembicSubDDeformNode::deform(MDataBlock& dataBlock, MItGeometry& iter,
     }
     iter.setPosition(abcPos);
   }
+  return MStatus::kSuccess;
+}
+
+// Cache the plug arrays for use in setDependentsDirty
+bool AlembicSubDDeformNode::setInternalValueInContext(const MPlug & plug,
+    const MDataHandle & dataHandle,
+    MDGContext &)
+{
+  if (plug == mGeomParamsList) {
+    MString geomParamsStr = dataHandle.asString();
+    getPlugArrayFromAttrList(geomParamsStr, thisMObject(), mGeomParamPlugs);
+  }
+  else if (plug == mUserAttrsList) {
+    MString userAttrsStr = dataHandle.asString();
+    getPlugArrayFromAttrList(userAttrsStr, thisMObject(), mUserAttrPlugs);
+  }
+
+  return false;
+}
+
+MStatus AlembicSubDDeformNode::setDependentsDirty(const MPlug &plugBeingDirtied,
+    MPlugArray &affectedPlugs)
+{
+  if (plugBeingDirtied == mFileNameAttr || plugBeingDirtied == mIdentifierAttr
+      || plugBeingDirtied == mTimeAttr) {
+
+    for (unsigned int i = 0; i < mGeomParamPlugs.length(); i++) {
+      affectedPlugs.append(mGeomParamPlugs[i]);
+    }
+
+    for (unsigned int i = 0; i < mUserAttrPlugs.length(); i++) {
+      affectedPlugs.append(mUserAttrPlugs[i]);
+    }
+  }
+
   return MStatus::kSuccess;
 }

--- a/Maya/AlembicSubD.h
+++ b/Maya/AlembicSubD.h
@@ -4,12 +4,16 @@
 #include <maya/MFnSubd.h>
 #include <maya/MUint64Array.h>
 #include "AlembicObject.h"
+#include "AttributesWriter.h"
 
 class AlembicSubD : public AlembicObject {
  private:
   AbcG::OSubD mObject;
   AbcG::OSubDSchema mSchema;
   AbcG::OSubDSchema::Sample mSample;
+
+  AttributesWriterPtr mAttrs;
+
   std::vector<Abc::V3f> mPosVec;
   std::vector<Abc::int32_t> mFaceCountVec;
   std::vector<Abc::int32_t> mFaceIndicesVec;
@@ -24,7 +28,8 @@ class AlembicSubD : public AlembicObject {
 
   virtual Abc::OObject GetObject() { return mObject; }
   virtual Abc::OCompoundProperty GetCompound() { return mSchema; }
-  virtual MStatus Save(double time);
+  virtual MStatus Save(double time, unsigned int timeIndex,
+      bool isFirstFrame);
 };
 
 class AlembicSubDNode : public AlembicObjectNode {

--- a/Maya/AlembicSubD.h
+++ b/Maya/AlembicSubD.h
@@ -43,6 +43,12 @@ class AlembicSubDNode : public AlembicObjectNode {
   static void* creator() { return (new AlembicSubDNode()); }
   static MStatus initialize();
 
+  bool setInternalValueInContext(const MPlug & plug,
+      const MDataHandle & dataHandle,
+      MDGContext & ctx);
+  MStatus setDependentsDirty(const MPlug &plugBeingDirtied,
+      MPlugArray &affectedPlugs);
+
  private:
   // input attributes
   static MObject mTimeAttr;
@@ -50,12 +56,17 @@ class AlembicSubDNode : public AlembicObjectNode {
   static MObject mIdentifierAttr;
   MString mFileName;
   MString mIdentifier;
+  MPlugArray mGeomParamPlugs;
+  MPlugArray mUserAttrPlugs;
   AbcG::ISubDSchema mSchema;
   static MObject mUvsAttr;
 
   // output attributes
   static MObject mOutGeometryAttr;
   static MObject mOutDispResolutionAttr;
+
+  static MObject mGeomParamsList;
+  static MObject mUserAttrsList;
 
   // members
   SampleInfo mLastSampleInfo;
@@ -75,6 +86,12 @@ class AlembicSubDDeformNode : public AlembicObjectDeformNode {
   static void* creator() { return (new AlembicSubDDeformNode()); }
   static MStatus initialize();
 
+  bool setInternalValueInContext(const MPlug & plug,
+      const MDataHandle & dataHandle,
+      MDGContext & ctx);
+  MStatus setDependentsDirty(const MPlug &plugBeingDirtied,
+      MPlugArray &affectedPlugs);
+
  private:
   // input attributes
   static MObject mTimeAttr;
@@ -82,8 +99,14 @@ class AlembicSubDDeformNode : public AlembicObjectDeformNode {
   static MObject mIdentifierAttr;
   MString mFileName;
   MString mIdentifier;
+  MPlugArray mGeomParamPlugs;
+  MPlugArray mUserAttrPlugs;
   AbcG::ISubDSchema mSchema;
   std::vector<unsigned int> mVertexLookup;
+
+  // output attributes
+  static MObject mGeomParamsList;
+  static MObject mUserAttrsList;
 
   // members
   SampleInfo mLastSampleInfo;

--- a/Maya/AlembicWriteJob.h
+++ b/Maya/AlembicWriteJob.h
@@ -1,6 +1,8 @@
 #ifndef _ALEMBIC_WRITE_JOB_H_
 #define _ALEMBIC_WRITE_JOB_H_
 
+#include <set>
+
 #include "AlembicObject.h"
 
 #include "CommonRegex.h"
@@ -18,6 +20,10 @@ class AlembicWriteJob {
   unsigned int mTs;
   std::map<std::string, std::string> mOptions;
   bool useOgawa;
+  std::vector<std::string> mPrefixFilters;
+  std::set<std::string> mAttributes;
+  std::vector<std::string> mUserPrefixFilters;
+  std::set<std::string> mUserAttributes;
 
   multiMapStrAbcObj mapObjects;
   double mFrameRate;
@@ -27,7 +33,11 @@ class AlembicWriteJob {
 
  public:
   AlembicWriteJob(const MString& in_FileName, const MObjectArray& in_Selection,
-                  const MDoubleArray& in_Frames, bool useOgawa);
+                  const MDoubleArray& in_Frames, bool useOgawa,
+                  const std::vector<std::string>& in_prefixFilters,
+                  const std::set<std::string>& in_attributes,
+                  const std::vector<std::string>& in_userPrefixFilters,
+                  const std::set<std::string>& in_userAttributes);
   ~AlembicWriteJob();
 
   // to change the name of objects while exporting!
@@ -38,6 +48,10 @@ class AlembicWriteJob {
   const std::vector<double>& GetFrames() { return mFrames; }
   const MString& GetFileName() { return mFileName; }
   unsigned int GetAnimatedTs() { return mTs; }
+  const std::vector<std::string>& GetPrefixFilters() const { return mPrefixFilters; }
+  const std::set<std::string>& GetAttributes() const { return mAttributes; }
+  const std::vector<std::string>& GetUserPrefixFilters() const { return mUserPrefixFilters; }
+  const std::set<std::string>& GetUserAttributes() const { return mUserAttributes; }
   void SetOption(const MString& in_Name, const MString& in_Value);
   bool HasOption(const MString& in_Name);
   MString GetOption(const MString& in_Name);

--- a/Maya/AlembicXform.cpp
+++ b/Maya/AlembicXform.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 
 #include "AlembicXform.h"
+#include "AttributesReading.h"
 #include "MetaData.h"
 
 #include <maya/MAnimUtil.h>
@@ -216,6 +217,9 @@ MObject AlembicXformNode::mOutScaleZAttr;
 MObject AlembicXformNode::mOutScaleAttr;
 MObject AlembicXformNode::mOutVisibilityAttr;
 
+MObject AlembicXformNode::mGeomParamsList;
+MObject AlembicXformNode::mUserAttrsList;
+
 MStatus AlembicXformNode::initialize()
 {
   MStatus status;
@@ -353,6 +357,24 @@ MStatus AlembicXformNode::initialize()
   status = nAttr.setHidden(false);
   status = addAttribute(mOutVisibilityAttr);
 
+  // output for list of ArbGeomParams
+  mGeomParamsList = tAttr.create("ExocortexAlembic_GeomParams", "exo_gp",
+      MFnData::kString, emptyStringObject);
+  status = tAttr.setStorable(true);
+  status = tAttr.setKeyable(false);
+  status = tAttr.setHidden(false);
+  status = tAttr.setInternal(true);
+  status = addAttribute(mGeomParamsList);
+
+  // output for list of UserAttributes
+  mUserAttrsList = tAttr.create("ExocortexAlembic_UserAttributes", "exo_ua",
+      MFnData::kString, emptyStringObject);
+  status = tAttr.setStorable(true);
+  status = tAttr.setKeyable(false);
+  status = tAttr.setHidden(false);
+  status = tAttr.setInternal(true);
+  status = addAttribute(mUserAttrsList);
+
   // create a mapping
   status = attributeAffects(mTimeAttr, mOutTranslateXAttr);
   status = attributeAffects(mFileNameAttr, mOutTranslateXAttr);
@@ -404,6 +426,17 @@ void AlembicXformNode::cleanDataHandles(MDataBlock &dataBlock)
   dataBlock.outputValue(mOutScaleZAttr).setClean();
 
   dataBlock.outputValue(mOutVisibilityAttr).setClean();
+
+  // Set all plugs as clean
+  // Even if one of them failed to get set,
+  // trying again in this frame isn't going to help
+  for (unsigned int i = 0; i < mGeomParamPlugs.length(); i++) {
+    dataBlock.outputValue(mGeomParamPlugs[i]).setClean();
+  }
+
+  for (unsigned int i = 0; i < mUserAttrPlugs.length(); i++) {
+    dataBlock.outputValue(mUserAttrPlugs[i]).setClean();
+  }
 }
 
 MStatus AlembicXformNode::compute(const MPlug &plug, MDataBlock &dataBlock)
@@ -460,6 +493,14 @@ MStatus AlembicXformNode::compute(const MPlug &plug, MDataBlock &dataBlock)
 
   if (mSchema.getNumSamples() == 0) {
     return MStatus::kFailure;
+  }
+
+  {
+    ESS_PROFILE_SCOPE("AlembicXformNode::compute readProps");
+    Alembic::Abc::ICompoundProperty arbProp = mSchema.getArbGeomParams();
+    Alembic::Abc::ICompoundProperty userProp = mSchema.getUserProperties();
+    readProps(inputTime, arbProp, dataBlock, thisMObject());
+    readProps(inputTime, userProp, dataBlock, thisMObject());
   }
 
   SampleInfo sampleInfo = getSampleInfo(inputTime, mSchema.getTimeSampling(),
@@ -565,4 +606,39 @@ MStatus AlembicXformNode::compute(const MPlug &plug, MDataBlock &dataBlock)
   }
 
   return status;
+}
+
+// Cache the plug arrays for use in setDependentsDirty
+bool AlembicXformNode::setInternalValueInContext(const MPlug & plug,
+    const MDataHandle & dataHandle,
+    MDGContext &)
+{
+  if (plug == mGeomParamsList) {
+    MString geomParamsStr = dataHandle.asString();
+    getPlugArrayFromAttrList(geomParamsStr, thisMObject(), mGeomParamPlugs);
+  }
+  else if (plug == mUserAttrsList) {
+    MString userAttrsStr = dataHandle.asString();
+    getPlugArrayFromAttrList(userAttrsStr, thisMObject(), mUserAttrPlugs);
+  }
+
+  return false;
+}
+
+MStatus AlembicXformNode::setDependentsDirty(const MPlug &plugBeingDirtied,
+    MPlugArray &affectedPlugs)
+{
+  if (plugBeingDirtied == mFileNameAttr || plugBeingDirtied == mIdentifierAttr
+      || plugBeingDirtied == mTimeAttr) {
+
+    for (unsigned int i = 0; i < mGeomParamPlugs.length(); i++) {
+      affectedPlugs.append(mGeomParamPlugs[i]);
+    }
+
+    for (unsigned int i = 0; i < mUserAttrPlugs.length(); i++) {
+      affectedPlugs.append(mUserAttrPlugs[i]);
+    }
+  }
+
+  return MStatus::kSuccess;
 }

--- a/Maya/AlembicXform.h
+++ b/Maya/AlembicXform.h
@@ -49,6 +49,12 @@ class AlembicXformNode : public AlembicObjectNode {
   static void* creator() { return (new AlembicXformNode()); }
   static MStatus initialize();
 
+  bool setInternalValueInContext(const MPlug & plug,
+      const MDataHandle & dataHandle,
+      MDGContext & ctx);
+  MStatus setDependentsDirty(const MPlug &plugBeingDirtied,
+      MPlugArray &affectedPlugs);
+
  private:
   // input attributes
   static MObject mTimeAttr;
@@ -56,6 +62,8 @@ class AlembicXformNode : public AlembicObjectNode {
   static MObject mIdentifierAttr;
   MString mFileName;
   MString mIdentifier;
+  MPlugArray mGeomParamPlugs;
+  MPlugArray mUserAttrPlugs;
   AbcG::IXformSchema mSchema;
   std::map<AbcA::index_t, Abc::M44d> mSampleIndicesToMatrices;
   Abc::M44d mLastMatrix;
@@ -81,6 +89,9 @@ class AlembicXformNode : public AlembicObjectNode {
   static MObject mOutScaleZAttr;
   static MObject mOutScaleAttr;
   static MObject mOutVisibilityAttr;
+
+  static MObject mGeomParamsList;
+  static MObject mUserAttrsList;
 };
 
 #endif

--- a/Maya/AlembicXform.h
+++ b/Maya/AlembicXform.h
@@ -2,6 +2,7 @@
 #define _ALEMBIC_XFORM_H_
 
 #include "AlembicObject.h"
+#include "AttributesWriter.h"
 
 enum VISIBILITY_TYPE { VISIBLE, NOT_VISIBLE, ANIMATED_VISIBLE };
 typedef struct __VisibilityInfo {
@@ -17,6 +18,9 @@ class AlembicXform : public AlembicObject {
   AbcG::OXform mObject;
   AbcG::OXformSchema mSchema;
   AbcG::XformSample mSample;
+
+  AttributesWriterPtr mAttrs;
+
   // AbcG::OVisibilityProperty mOVisibility;
   VisibilityInfo visInfo;
 
@@ -30,7 +34,8 @@ class AlembicXform : public AlembicObject {
 
   virtual Abc::OObject GetObject() { return mObject; }
   virtual Abc::OCompoundProperty GetCompound() { return mSchema; }
-  virtual MStatus Save(double time);
+  virtual MStatus Save(double time, unsigned int timeIndex,
+      bool isFirstFrame);
 };
 
 class AlembicXformNode : public AlembicObjectNode {

--- a/Maya/AttributesReading.cpp
+++ b/Maya/AttributesReading.cpp
@@ -1,0 +1,2575 @@
+//-*****************************************************************************
+//
+// Copyright (c) 2009-2013,
+//  Sony Pictures Imageworks, Inc. and
+//  Industrial Light & Magic, a division of Lucasfilm Entertainment Company Ltd.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+// *       Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// *       Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+// *       Neither the name of Sony Pictures Imageworks, nor
+// Industrial Light & Magic nor the names of their contributors may be used
+// to endorse or promote products derived from this software without specific
+// prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//-*****************************************************************************
+#include "stdafx.h"
+
+#include "AttributesReading.h"
+
+#include <Alembic/AbcCoreFactory/IFactory.h>
+
+#include <maya/MDoubleArray.h>
+#include <maya/MIntArray.h>
+#include <maya/MFnIntArrayData.h>
+#include <maya/MPlug.h>
+#include <maya/MPointArray.h>
+#include <maya/MUint64Array.h>
+#include <maya/MStringArray.h>
+#include <maya/MFnData.h>
+#include <maya/MFnDoubleArrayData.h>
+#include <maya/MFnTypedAttribute.h>
+#include <maya/MFnNumericAttribute.h>
+#include <maya/MFnNumericData.h>
+#include <maya/MFnStringData.h>
+#include <maya/MFnStringArrayData.h>
+#include <maya/MFnPointArrayData.h>
+#include <maya/MFnVectorArrayData.h>
+#include <maya/MFnMesh.h>
+#include <maya/MFnTransform.h>
+#include <maya/MFnDependencyNode.h>
+#include <maya/MObjectArray.h>
+#include <maya/MDGModifier.h>
+#include <maya/MSelectionList.h>
+#include <maya/MFnLight.h>
+#include <maya/MFnNurbsCurve.h>
+#include <maya/MFnNurbsSurface.h>
+#include <maya/MFnCamera.h>
+#include <maya/MTime.h>
+
+double getWeightAndIndex(double iFrame,
+    Alembic::AbcCoreAbstract::TimeSamplingPtr iTime, size_t numSamps,
+    Alembic::AbcCoreAbstract::index_t & oIndex,
+    Alembic::AbcCoreAbstract::index_t & oCeilIndex)
+{
+  if (numSamps == 0)
+    numSamps = 1;
+
+  std::pair<Alembic::AbcCoreAbstract::index_t, double> floorIndex =
+    iTime->getFloorIndex(iFrame, numSamps);
+
+  oIndex = floorIndex.first;
+  oCeilIndex = oIndex;
+
+  if (fabs(iFrame - floorIndex.second) < 0.0001)
+    return 0.0;
+
+  std::pair<Alembic::AbcCoreAbstract::index_t, double> ceilIndex =
+    iTime->getCeilIndex(iFrame, numSamps);
+
+  if (oIndex == ceilIndex.first)
+    return 0.0;
+
+  oCeilIndex = ceilIndex.first;
+
+  double alpha = (iFrame - floorIndex.second) /
+    (ceilIndex.second - floorIndex.second);
+
+  // we so closely match the ceiling so we'll just use it
+  if (fabs(1.0 - alpha) < 0.0001)
+  {
+    oIndex = oCeilIndex;
+    return 0.0;
+  }
+
+  return alpha;
+}
+
+template<typename T>
+T simpleLerp(double alpha, T val1, T val2)
+{
+  double dv = static_cast<double>( val1 );
+  return static_cast<T>( dv + alpha * (static_cast<double>(val2) - dv) );
+}
+
+template <class T>
+void unsupportedWarning(T & iProp)
+{
+    MString warn = "Unsupported attr, skipping: ";
+    warn += iProp.getName().c_str();
+    warn += " ";
+    warn += PODName(iProp.getDataType().getPod());
+    warn += "[";
+    warn += iProp.getDataType().getExtent();
+    warn += "]";
+
+    MGlobal::displayWarning(warn);
+}
+
+void addString(MObject & iParent, const std::string & iAttrName,
+    const std::string & iValue)
+{
+    MFnStringData fnStringData;
+    MString attrValue(iValue.c_str());
+    MString attrName(iAttrName.c_str());
+    MObject strAttrObject = fnStringData.create("");
+
+    MFnTypedAttribute attr;
+    MObject attrObj = attr.create(attrName, attrName, MFnData::kString,
+        strAttrObject);
+    MFnDependencyNode parentFn(iParent);
+    parentFn.addAttribute(attrObj, MFnDependencyNode::kLocalDynamicAttr);
+
+    // work around bug where this string wasn't getting saved to a file when
+    // it is the default value
+    MPlug plug = parentFn.findPlug(attrName);
+    if (!plug.isNull())
+    {
+        plug.setString(attrValue);
+    }
+}
+
+void addArbAttrAndScope(MObject & iParent, const std::string & iAttrName,
+    const std::string & iScope, const std::string & iInterp,
+    Alembic::Util::uint8_t iExtent)
+{
+
+    std::string attrStr;
+
+    // constant scope colors can use setUsedAsColor
+    if (iInterp == "rgb" && iScope != "" && iScope != "con")
+    {
+        attrStr = "rgb";
+    }
+    else if (iInterp == "rgba" && iScope != "" && iScope != "con")
+    {
+        attrStr = "rgba";
+    }
+    else if (iInterp == "vector")
+    {
+        if (iExtent == 2)
+            attrStr = "vector2";
+        // the data type makes it intrinsically a vector3
+    }
+    else if (iInterp == "point")
+    {
+        if (iExtent == 2)
+            attrStr = "point2";
+        // the data type is treated intrinsically as a point3
+    }
+    else if (iInterp == "normal")
+    {
+        if (iExtent == 2)
+            attrStr = "normal2";
+        else if (iExtent == 3)
+            attrStr = "normal3";
+    }
+
+    if (attrStr != "")
+    {
+        std::string attrName = iAttrName + "_AbcType";
+        addString(iParent, attrName, attrStr);
+    }
+
+    if (iScope != "" && iScope != "con")
+    {
+        std::string attrName = iAttrName + "_AbcGeomScope";
+        addString(iParent, attrName, iScope);
+    }
+}
+
+bool addArrayProp(Alembic::Abc::IArrayProperty & iProp, MObject & iParent,
+        bool isWritable,
+        std::ostringstream &attrsList)
+{
+    MFnDependencyNode parentFn(iParent);
+    MString attrName(iProp.getName().c_str());
+    MPlug plug = parentFn.findPlug(attrName);
+
+    MFnTypedAttribute typedAttr;
+    MFnNumericAttribute numAttr;
+
+    MObject attrObj;
+    Alembic::AbcCoreAbstract::DataType dtype = iProp.getDataType();
+    Alembic::Util::uint8_t extent = dtype.getExtent();
+    std::string interp = iProp.getMetaData().get("interpretation");
+
+    bool isScalarLike = iProp.isScalarLike() &&
+        iProp.getMetaData().get("isArray") != "1";
+
+    // the first sample is read only when the property is constant
+    switch (dtype.getPod())
+    {
+        case Alembic::Util::kBooleanPOD:
+        {
+            if (extent != 1 || !isScalarLike)
+            {
+                return false;
+            }
+
+            bool bval = 0;
+
+            if (iProp.isConstant())
+            {
+                Alembic::AbcCoreAbstract::ArraySamplePtr val;
+                iProp.get(val);
+                bval =
+                    ((Alembic::Util::bool_t *)(val->getData()))[0] != false;
+            }
+
+            if (plug.isNull())
+            {
+                attrObj = numAttr.create(attrName, attrName,
+                    MFnNumericData::kBoolean, bval);
+            }
+            else
+            {
+                plug.setValue(bval);
+            }
+        }
+        break;
+
+        case Alembic::Util::kUint8POD:
+        case Alembic::Util::kInt8POD:
+        {
+            if (extent != 1 || !isScalarLike)
+            {
+                return false;
+            }
+
+            // default is 1 just to accomodate visiblitity
+            Alembic::Util::int8_t val = 1;
+
+            if (iProp.isConstant())
+            {
+                Alembic::AbcCoreAbstract::ArraySamplePtr samp;
+                iProp.get(samp);
+                val = ((Alembic::Util::int8_t *) samp->getData())[0];
+            }
+
+            if (plug.isNull())
+            {
+                attrObj = numAttr.create(attrName, attrName,
+                    MFnNumericData::kByte, val);
+            }
+            else
+            {
+                plug.setValue(val);
+                attrsList << ";" << attrName;
+
+                return true;
+            }
+        }
+        break;
+
+        case Alembic::Util::kInt16POD:
+        case Alembic::Util::kUint16POD:
+        {
+            // MFnNumericData::kShort or k2Short or k3Short
+            if (extent > 3 || !isScalarLike)
+            {
+                return false;
+            }
+
+            Alembic::Util::int16_t val[3] = {0, 0, 0};
+
+            if (iProp.isConstant())
+            {
+                Alembic::AbcCoreAbstract::ArraySamplePtr samp;
+                iProp.get(samp);
+                const Alembic::Util::int16_t * sampData =
+                    (const Alembic::Util::int16_t *) samp->getData();
+
+                for (Alembic::Util::uint8_t i = 0; i < extent; ++i)
+                {
+                    val[i] = sampData[i];
+                }
+            }
+
+            if (!plug.isNull())
+            {
+                unsigned int numChildren = plug.numChildren();
+                if (numChildren == 0)
+                {
+                    plug.setValue(val[0]);
+                }
+                else
+                {
+                    if (numChildren > extent)
+                        numChildren = extent;
+
+                    for (unsigned int i = 0; i < numChildren; ++i)
+                    {
+                        plug.child(i).setValue(val[i]);
+                    }
+                }
+                attrsList << ";" << attrName;
+
+                return true;
+            }
+            else if (extent == 1)
+            {
+                attrObj = numAttr.create(attrName, attrName,
+                    MFnNumericData::kShort);
+                numAttr.setDefault(val[0]);
+            }
+            else if (extent == 2)
+            {
+                attrObj = numAttr.create(attrName, attrName,
+                    MFnNumericData::k2Short);
+                numAttr.setDefault(val[0], val[1]);
+            }
+            else if (extent == 3)
+            {
+                attrObj = numAttr.create(attrName, attrName,
+                    MFnNumericData::k3Short);
+                numAttr.setDefault(val[0], val[1], val[2]);
+            }
+        }
+        break;
+
+        case Alembic::Util::kUint32POD:
+        case Alembic::Util::kInt32POD:
+        {
+            if (!isScalarLike)
+            {
+                MFnIntArrayData fnData;
+                MObject arrObj;
+
+                if (iProp.isConstant())
+                {
+                    Alembic::AbcCoreAbstract::ArraySamplePtr samp;
+                    iProp.get(samp);
+
+                    MIntArray arr((int *) samp->getData(),
+                        static_cast<unsigned int>(samp->size()));
+                    arrObj = fnData.create(arr);
+                    if (!plug.isNull())
+                    {
+                        plug.setValue(arrObj);
+                        attrsList << ";" << attrName;
+
+                        return true;
+                    }
+                }
+                else
+                {
+                    MIntArray arr;
+                    arrObj = fnData.create(arr);
+                }
+
+                attrObj = typedAttr.create(attrName, attrName,
+                    MFnData::kIntArray, arrObj);
+            }
+            // isScalarLike
+            else
+            {
+                if (extent > 3)
+                {
+                    return false;
+                }
+
+                Alembic::Util::int32_t val[3] = {0, 0, 0};
+
+                if (iProp.isConstant())
+                {
+                    Alembic::AbcCoreAbstract::ArraySamplePtr samp;
+                    iProp.get(samp);
+                    const Alembic::Util::int32_t * sampData =
+                        (const Alembic::Util::int32_t *)samp->getData();
+                    for (Alembic::Util::uint8_t i = 0; i < extent; ++i)
+                    {
+                        val[i] = sampData[i];
+                    }
+                }
+
+                if (!plug.isNull())
+                {
+                    unsigned int numChildren = plug.numChildren();
+                    if (numChildren == 0)
+                    {
+                        plug.setValue(val[0]);
+                    }
+                    else
+                    {
+                        if (numChildren > extent)
+                            numChildren = extent;
+
+                        for (unsigned int i = 0; i < numChildren; ++i)
+                        {
+                            plug.child(i).setValue(val[i]);
+                        }
+                    }
+                    attrsList << ";" << attrName;
+
+                    return true;
+                }
+                else if (extent == 1)
+                {
+                    attrObj = numAttr.create(attrName, attrName,
+                        MFnNumericData::kInt);
+                    numAttr.setDefault(val[0]);
+                }
+                else if (extent == 2)
+                {
+                    attrObj = numAttr.create(attrName, attrName,
+                        MFnNumericData::k2Int);
+                    numAttr.setDefault(val[0], val[1]);
+                }
+                else if (extent == 3)
+                {
+                    attrObj = numAttr.create(attrName, attrName,
+                        MFnNumericData::k3Int);
+                    numAttr.setDefault(val[0], val[1], val[2]);
+                }
+            }
+        }
+        break;
+
+        // look for MFnVectorArrayData?
+        case Alembic::Util::kFloat32POD:
+        {
+            if (!isScalarLike)
+            {
+                if ((extent == 2 || extent == 3) && (interp == "normal" ||
+                    interp == "vector" || interp == "rgb"))
+                {
+                    MFnVectorArrayData fnData;
+                    MObject arrObj;
+
+                    if (iProp.isConstant())
+                    {
+                        Alembic::AbcCoreAbstract::ArraySamplePtr samp;
+                        iProp.get(samp);
+
+                        unsigned int sampSize = (unsigned int)samp->size();
+                        MVectorArray arr(sampSize);
+                        MVector vec;
+                        const Alembic::Util::float32_t * sampData =
+                            (const Alembic::Util::float32_t *) samp->getData();
+
+                        for (unsigned int i = 0; i < sampSize; ++i)
+                        {
+                            vec.x = sampData[extent*i];
+                            vec.y = sampData[extent*i+1];
+
+                            if (extent == 3)
+                            {
+                                vec.z = sampData[extent*i+2];
+                            }
+                            arr[i] = vec;
+                        }
+
+                        arrObj = fnData.create(arr);
+                        if (!plug.isNull())
+                        {
+                            plug.setValue(arrObj);
+                            attrsList << ";" << attrName;
+
+                            return true;
+                        }
+                    }
+                    else
+                    {
+                        MVectorArray arr;
+                        arrObj = fnData.create(arr);
+                    }
+
+                    attrObj = typedAttr.create(attrName, attrName,
+                        MFnData::kVectorArray, arrObj);
+                }
+                else if (interp == "point" && (extent == 2 || extent == 3))
+                {
+                    MFnPointArrayData fnData;
+                    MObject arrObj;
+
+                    if (iProp.isConstant())
+                    {
+                        Alembic::AbcCoreAbstract::ArraySamplePtr samp;
+                        iProp.get(samp);
+
+                        unsigned int sampSize = (unsigned int)samp->size();
+                        MPointArray arr(sampSize);
+                        MPoint pt;
+
+                        const Alembic::Util::float32_t * sampData =
+                            (const Alembic::Util::float32_t *) samp->getData();
+
+                        for (unsigned int i = 0; i < sampSize; ++i)
+                        {
+                            pt.x = sampData[extent*i];
+                            pt.y = sampData[extent*i+1];
+
+                            if (extent == 3)
+                            {
+                                pt.z = sampData[extent*i+2];
+                            }
+                            arr[i] = pt;
+                        }
+
+                        arrObj = fnData.create(arr);
+                        if (!plug.isNull())
+                        {
+                            plug.setValue(arrObj);
+                            attrsList << ";" << attrName;
+
+                            return true;
+                        }
+                    }
+                    else
+                    {
+                        MPointArray arr;
+                        arrObj = fnData.create(arr);
+                    }
+
+                    attrObj = typedAttr.create(attrName, attrName,
+                        MFnData::kPointArray, arrObj);
+                }
+                else
+                {
+                    MFnDoubleArrayData fnData;
+                    MObject arrObj;
+
+                    if (iProp.isConstant())
+                    {
+                        Alembic::AbcCoreAbstract::ArraySamplePtr samp;
+                        iProp.get(samp);
+
+                        MDoubleArray arr((float *) samp->getData(),
+                            static_cast<unsigned int>(samp->size()));
+                        arrObj = fnData.create(arr);
+                        if (!plug.isNull())
+                        {
+                            plug.setValue(arrObj);
+                            attrsList << ";" << attrName;
+
+                            return true;
+                        }
+                    }
+                    else
+                    {
+                        MDoubleArray arr;
+                        arrObj = fnData.create(arr);
+                    }
+
+                    attrObj = typedAttr.create(attrName, attrName,
+                        MFnData::kDoubleArray, arrObj);
+                }
+
+            }
+            // isScalarLike
+            else
+            {
+                if (extent > 3)
+                {
+                    return false;
+                }
+
+                float val[3] = {0, 0, 0};
+
+                if (iProp.isConstant())
+                {
+                    Alembic::AbcCoreAbstract::ArraySamplePtr samp;
+                    iProp.get(samp);
+                    const float * sampData = (const float *) samp->getData();
+                    for (Alembic::Util::uint8_t i = 0; i < extent; ++i)
+                    {
+                        val[i] = sampData[i];
+                    }
+                }
+
+                if (!plug.isNull())
+                {
+                    unsigned int numChildren = plug.numChildren();
+                    if (numChildren == 0)
+                    {
+                        plug.setValue(val[0]);
+                    }
+                    else
+                    {
+                        if (numChildren > extent)
+                            numChildren = extent;
+
+                        for (unsigned int i = 0; i < numChildren; ++i)
+                        {
+                            plug.child(i).setValue(val[i]);
+                        }
+                    }
+                    attrsList << ";" << attrName;
+
+                    return true;
+                }
+                else if (extent == 1)
+                {
+                    attrObj = numAttr.create(attrName, attrName,
+                        MFnNumericData::kFloat);
+                    numAttr.setDefault(val[0]);
+                }
+                else if (extent == 2)
+                {
+                    attrObj = numAttr.create(attrName, attrName,
+                        MFnNumericData::k2Float);
+                    numAttr.setDefault(val[0], val[1]);
+                }
+                else if (extent == 3)
+                {
+                    if (interp == "rgb")
+                    {
+                        attrObj = numAttr.createColor(attrName, attrName);
+                    }
+                    else if (interp == "point")
+                    {
+                        attrObj = numAttr.createPoint(attrName, attrName);
+                    }
+                    else
+                    {
+                        attrObj = numAttr.create(attrName, attrName,
+                            MFnNumericData::k3Float);
+                    }
+                    numAttr.setDefault(val[0], val[1], val[2]);
+                }
+            }
+        }
+        break;
+
+        case Alembic::Util::kFloat64POD:
+        {
+            if (!isScalarLike)
+            {
+                if ((extent == 2 || extent == 3) && (interp == "normal" ||
+                    interp == "vector" || interp == "rgb"))
+                {
+                    MFnVectorArrayData fnData;
+                    MObject arrObj;
+
+                    if (iProp.isConstant())
+                    {
+                        Alembic::AbcCoreAbstract::ArraySamplePtr samp;
+                        iProp.get(samp);
+
+                        unsigned int sampSize = (unsigned int)samp->size();
+                        MVectorArray arr(sampSize);
+                        MVector vec;
+                        const Alembic::Util::float64_t * sampData =
+                            (const Alembic::Util::float64_t *) samp->getData();
+
+                        for (unsigned int i = 0; i < sampSize; ++i)
+                        {
+                            vec.x = sampData[extent*i];
+                            vec.y = sampData[extent*i+1];
+
+                            if (extent == 3)
+                            {
+                                vec.z = sampData[extent*i+2];
+                            }
+
+                            arr[i] = vec;
+                        }
+
+                        arrObj = fnData.create(arr);
+                        if (!plug.isNull())
+                        {
+                            plug.setValue(arrObj);
+                            attrsList << ";" << attrName;
+
+                            return true;
+                        }
+                    }
+                    else
+                    {
+                        MVectorArray arr;
+                        arrObj = fnData.create(arr);
+                    }
+
+                    attrObj = typedAttr.create(attrName, attrName,
+                        MFnData::kVectorArray, arrObj);
+                }
+                else if (interp == "point" && (extent == 2 || extent == 3))
+                {
+                    MFnPointArrayData fnData;
+                    MObject arrObj;
+
+                    if (iProp.isConstant())
+                    {
+                        Alembic::AbcCoreAbstract::ArraySamplePtr samp;
+                        iProp.get(samp);
+
+                        unsigned int sampSize = (unsigned int)samp->size();
+                        MPointArray arr(sampSize);
+                        MPoint pt;
+                        const Alembic::Util::float64_t * sampData =
+                            (const Alembic::Util::float64_t *) samp->getData();
+
+                        for (unsigned int i = 0; i < sampSize; ++i)
+                        {
+                            pt.x = sampData[extent*i];
+                            pt.y = sampData[extent*i+1];
+
+                            if (extent == 3)
+                            {
+                                pt.z = sampData[extent*i+2];
+                            }
+
+                            arr[i] = pt;
+                        }
+
+                        arrObj = fnData.create(arr);
+                        if (!plug.isNull())
+                        {
+                            plug.setValue(arrObj);
+                            attrsList << ";" << attrName;
+
+                            return true;
+                        }
+                    }
+                    else
+                    {
+                        MPointArray arr;
+                        arrObj = fnData.create(arr);
+                    }
+
+                    attrObj = typedAttr.create(attrName, attrName,
+                        MFnData::kPointArray, arrObj);
+                }
+                else
+                {
+                    MFnDoubleArrayData fnData;
+                    MObject arrObj;
+
+                    if (iProp.isConstant())
+                    {
+                        Alembic::AbcCoreAbstract::ArraySamplePtr samp;
+                        iProp.get(samp);
+
+                        MDoubleArray arr((double *) samp->getData(),
+                            static_cast<unsigned int>(samp->size()));
+                        arrObj = fnData.create(arr);
+                        if (!plug.isNull())
+                        {
+                            plug.setValue(arrObj);
+                            attrsList << ";" << attrName;
+
+                            return true;
+                        }
+                    }
+                    else
+                    {
+                        MDoubleArray arr;
+                        arrObj = fnData.create(arr);
+                    }
+
+                    attrObj = typedAttr.create(attrName, attrName,
+                        MFnData::kDoubleArray, arrObj);
+                }
+
+            }
+            else
+            {
+                if (extent > 4)
+                {
+                    return false;
+                }
+
+                attrsList << ";" << attrName;
+
+                double val[4] = {0, 0, 0, 0};
+
+                if (iProp.isConstant())
+                {
+                    Alembic::AbcCoreAbstract::ArraySamplePtr samp;
+                    iProp.get(samp);
+                    const double * sampData = (const double *) samp->getData();
+                    for (Alembic::Util::uint8_t i = 0; i < extent; ++i)
+                    {
+                        val[i] = sampData[i];
+                    }
+                }
+
+                if (!plug.isNull())
+                {
+                    unsigned int numChildren = plug.numChildren();
+                    if (numChildren == 0)
+                    {
+                        plug.setValue(val[0]);
+                    }
+                    else
+                    {
+                        if (numChildren > extent)
+                            numChildren = extent;
+
+                        for (unsigned int i = 0; i < numChildren; ++i)
+                        {
+                            plug.child(i).setValue(val[i]);
+                        }
+                    }
+                    attrsList << ";" << attrName;
+
+                    return true;
+                }
+                else if (extent == 1)
+                {
+                    if (plug.isNull())
+                    {
+                        attrObj = numAttr.create(attrName, attrName,
+                            MFnNumericData::kDouble);
+                        numAttr.setDefault(val[0]);
+                    }
+                    else
+                    {
+                        plug.setValue(val[0]);
+                        attrsList << ";" << attrName;
+
+                        return true;
+                    }
+                }
+                else if (extent == 2)
+                {
+                    attrObj = numAttr.create(attrName, attrName,
+                        MFnNumericData::k2Double);
+                    numAttr.setDefault(val[0], val[1]);
+                }
+                else if (extent == 3)
+                {
+                    attrObj = numAttr.create(attrName, attrName,
+                        MFnNumericData::k3Double);
+                    numAttr.setDefault(val[0], val[1], val[2]);
+                }
+                else if (extent == 4)
+                {
+                    attrObj = numAttr.create(attrName, attrName,
+                        MFnNumericData::k4Double);
+                    numAttr.setDefault(val[0], val[1], val[2], val[4]);
+                }
+            }
+        }
+        break;
+
+        // MFnStringArrayData
+        case Alembic::Util::kStringPOD:
+        {
+            if (!isScalarLike)
+            {
+                MFnStringArrayData fnData;
+                MObject arrObj;
+
+                if (iProp.isConstant())
+                {
+                    Alembic::AbcCoreAbstract::ArraySamplePtr samp;
+                    iProp.get(samp);
+
+                    unsigned int sampSize = (unsigned int)samp->size();
+                    MStringArray arr;
+                    arr.setLength(sampSize);
+
+                    Alembic::Util::string * strData =
+                        (Alembic::Util::string *) samp->getData();
+
+                    for (unsigned int i = 0; i < sampSize; ++i)
+                    {
+                        arr[i] = strData[i].c_str();
+                    }
+                    arrObj = fnData.create(arr);
+                    if (!plug.isNull())
+                    {
+                        plug.setValue(arrObj);
+                        attrsList << ";" << attrName;
+
+                        return true;
+                    }
+                }
+                else
+                {
+                    MStringArray arr;
+                    arrObj = fnData.create(arr);
+                }
+
+                attrObj = typedAttr.create(attrName, attrName,
+                    MFnData::kStringArray, arrObj);
+            }
+            // isScalarLike
+            else
+            {
+                if (extent != 1)
+                {
+                    return false;
+                }
+
+                MFnStringData fnStringData;
+                MObject strAttrObject;
+
+                if (iProp.isConstant())
+                {
+                    Alembic::AbcCoreAbstract::ArraySamplePtr samp;
+                    iProp.get(samp);
+                    MString attrValue(
+                        ((Alembic::Util::string *) samp->getData())[0].c_str());
+                    strAttrObject = fnStringData.create(attrValue);
+                    if (!plug.isNull())
+                    {
+                        plug.setValue(strAttrObject);
+                        attrsList << ";" << attrName;
+
+                        return true;
+                    }
+                }
+                else
+                {
+                    MString attrValue;
+                    strAttrObject = fnStringData.create(attrValue);
+                }
+
+                attrObj = typedAttr.create(attrName, attrName, MFnData::kString,
+                        MObject::kNullObj);
+
+                parentFn.addAttribute(attrObj,
+                    MFnDependencyNode::kLocalDynamicAttr);
+
+                plug = parentFn.findPlug(attrName);
+                if (!plug.isNull())
+                {
+                    plug.setValue(strAttrObject);
+                }
+            }
+        }
+        break;
+
+        // MFnStringArrayData
+        case Alembic::Util::kWstringPOD:
+        {
+            if (!isScalarLike)
+            {
+                MFnStringArrayData fnData;
+                MObject arrObj;
+
+                if (iProp.isConstant())
+                {
+                    Alembic::AbcCoreAbstract::ArraySamplePtr samp;
+                    iProp.get(samp);
+
+                    unsigned int sampSize = (unsigned int)samp->size();
+                    MStringArray arr;
+                    arr.setLength(sampSize);
+
+                    Alembic::Util::wstring * strData =
+                        (Alembic::Util::wstring *) samp->getData();
+
+                    for (unsigned int i = 0; i < sampSize; ++i)
+                    {
+                        arr[i] = (wchar_t *)(strData[i].c_str());
+                    }
+                    arrObj = fnData.create(arr);
+
+                    if (!plug.isNull())
+                    {
+                        plug.setValue(arrObj);
+                        attrsList << ";" << attrName;
+
+                        return true;
+                    }
+                }
+                else
+                {
+                    MStringArray arr;
+                    arrObj = fnData.create(arr);
+                }
+
+                attrObj = typedAttr.create(attrName, attrName,
+                    MFnData::kStringArray, arrObj);
+            }
+            // isScalarLike
+            else
+            {
+                if (extent != 1)
+                {
+                    return false;
+                }
+
+                MFnStringData fnStringData;
+                MObject strAttrObject;
+
+                if (iProp.isConstant())
+                {
+                    Alembic::AbcCoreAbstract::ArraySamplePtr samp;
+                    iProp.get(samp);
+                    MString attrValue(
+                        ((Alembic::Util::wstring *)samp->getData())[0].c_str());
+                    strAttrObject = fnStringData.create(attrValue);
+                    if (!plug.isNull())
+                    {
+                        plug.setValue(strAttrObject);
+                        attrsList << ";" << attrName;
+
+                        return true;
+                    }
+                }
+                else
+                {
+                    MString attrValue;
+                    strAttrObject = fnStringData.create(attrValue);
+                }
+
+                attrObj = typedAttr.create(attrName, attrName, MFnData::kString,
+                        MObject::kNullObj);
+
+                parentFn.addAttribute(attrObj,  MFnDependencyNode::kLocalDynamicAttr);
+
+                plug = parentFn.findPlug(attrName);
+                if (!plug.isNull())
+                {
+                    plug.setValue(strAttrObject);
+                }
+            }
+        }
+        break;
+
+        default:
+        {
+            // Not sure what to do with kFloat16POD, kInt64POD, kUInt64POD
+            // so we'll just skip them for now
+            return false;
+        }
+        break;
+    }
+
+    typedAttr.setKeyable(true);
+    numAttr.setKeyable(true);
+    typedAttr.setWritable(isWritable);
+    numAttr.setWritable(isWritable);
+    typedAttr.setReadable(true);
+    numAttr.setReadable(true);
+
+    if (isScalarLike && interp == "rgb")
+    {
+        typedAttr.setUsedAsColor(true);
+        numAttr.setUsedAsColor(true);
+    }
+
+    if ( ! parentFn.hasAttribute( attrName ) )
+    {
+        parentFn.addAttribute(attrObj,  MFnDependencyNode::kLocalDynamicAttr);
+    }
+
+    addArbAttrAndScope(iParent, iProp.getName(),
+        iProp.getMetaData().get("geoScope"), interp, extent);
+
+    plug = parentFn.findPlug(attrName);
+    if (!plug.isNull()) {
+        attrsList << ";" << attrName;
+    }
+
+    return true;
+}
+
+template <class PODTYPE>
+AddPropResult
+addScalarExtentOneProp(Alembic::Abc::IScalarProperty& iProp,
+                       Alembic::Util::uint8_t extent,
+                       PODTYPE defaultVal,
+                       MPlug& plug,
+                       MString& attrName,
+                       MFnNumericAttribute& numAttr,
+                       MObject& attrObj,
+                       MFnNumericData::Type type)
+{
+    if (extent != 1)
+        return INVALID;
+
+    static const Alembic::Abc::ISampleSelector iss((Alembic::Abc::index_t)0);
+
+    PODTYPE val = defaultVal;
+    if (iProp.isConstant())
+        iProp.get(&val, iss);
+
+    if (plug.isNull())
+    {
+        attrObj = numAttr.create(attrName, attrName, type, val);
+    }
+    else
+    {
+        plug.setValue(val);
+        return VALID_DONE;
+    }
+
+    return VALID_NOTDONE;
+}
+
+template <class PODTYPE>
+AddPropResult
+addScalarExtentThreeProp(Alembic::Abc::IScalarProperty& iProp,
+                         Alembic::Util::uint8_t extent,
+                         PODTYPE defaultVal,
+                         MPlug& plug,
+                         MString& attrName,
+                         MFnNumericAttribute& numAttr,
+                         MObject& attrObj,
+                         MFnNumericData::Type type1,
+                         MFnNumericData::Type type2,
+                         MFnNumericData::Type type3)
+{
+    if (extent > 3)
+        return INVALID;
+
+    static const Alembic::Abc::ISampleSelector iss((Alembic::Abc::index_t)0);
+
+    PODTYPE val[3] = {defaultVal, defaultVal, defaultVal};
+
+    if (iProp.isConstant())
+        iProp.get(&val, iss);
+
+    if (!plug.isNull())
+    {
+        unsigned int numChildren = plug.numChildren();
+        if (numChildren == 0)
+        {
+            plug.setValue(val[0]);
+        }
+        else
+        {
+            if (numChildren > extent)
+                numChildren = extent;
+
+            for (unsigned int i = 0; i < numChildren; ++i)
+                plug.child(i).setValue(val[i]);
+        }
+        return VALID_DONE;
+    }
+    else if (extent == 1)
+    {
+        attrObj = numAttr.create(attrName, attrName, type1);
+        numAttr.setDefault(val[0]);
+    }
+    else if (extent == 2)
+    {
+        attrObj = numAttr.create(attrName, attrName, type2);
+        numAttr.setDefault(val[0], val[1]);
+    }
+    else if (extent == 3)
+    {
+        attrObj = numAttr.create(attrName, attrName, type3);
+        numAttr.setDefault(val[0], val[1], val[2]);
+    }
+
+    return VALID_NOTDONE;
+}
+
+template <class PODTYPE>
+AddPropResult
+addScalarExtentFourProp(Alembic::Abc::IScalarProperty& iProp,
+                        Alembic::Util::uint8_t extent,
+                        PODTYPE defaultVal,
+                        MPlug& plug,
+                        MString& attrName,
+                        MFnNumericAttribute& numAttr,
+                        MObject& attrObj,
+                        MFnNumericData::Type type1,
+                        MFnNumericData::Type type2,
+                        MFnNumericData::Type type3,
+                        MFnNumericData::Type type4)
+{
+    if (extent > 4)
+        return INVALID;
+
+    static const Alembic::Abc::ISampleSelector iss((Alembic::Abc::index_t)0);
+
+    PODTYPE val[4] = {defaultVal, defaultVal, defaultVal, defaultVal};
+
+    if (iProp.isConstant())
+        iProp.get(&val, iss);
+
+    if (!plug.isNull())
+    {
+        unsigned int numChildren = plug.numChildren();
+        if (numChildren == 0)
+        {
+            plug.setValue(val[0]);
+        }
+        else
+        {
+            if (numChildren > extent)
+                numChildren = extent;
+
+            for (unsigned int i = 0; i < numChildren; ++i)
+            {
+                plug.child(i).setValue(val[i]);
+            }
+        }
+
+        return VALID_DONE;
+    }
+    else if (extent == 1)
+    {
+        attrObj = numAttr.create(attrName, attrName, type1);
+        numAttr.setDefault(val[0]);
+    }
+    else if (extent == 2)
+    {
+        attrObj = numAttr.create(attrName, attrName, type2);
+        numAttr.setDefault(val[0], val[1]);
+    }
+    else if (extent == 3)
+    {
+        attrObj = numAttr.create(attrName, attrName, type3);
+        numAttr.setDefault(val[0], val[1], val[2]);
+    }
+    else if (extent == 4)
+    {
+        attrObj = numAttr.create(attrName, attrName, type4);
+        numAttr.setDefault(val[0], val[1], val[2], val[4]);
+    }
+
+    return VALID_NOTDONE;
+}
+
+bool addScalarProp(Alembic::Abc::IScalarProperty & iProp, MObject & iParent,
+        bool isWritable,
+        std::ostringstream &attrsList)
+{
+    MFnDependencyNode parentFn(iParent);
+    MString attrName(iProp.getName().c_str());
+    MPlug plug = parentFn.findPlug(attrName);
+
+    MFnTypedAttribute typedAttr;
+    MFnNumericAttribute numAttr;
+
+    MObject attrObj;
+    Alembic::AbcCoreAbstract::DataType dtype = iProp.getDataType();
+    Alembic::Util::uint8_t extent = dtype.getExtent();
+    std::string interp = iProp.getMetaData().get("interpretation");
+
+    switch (dtype.getPod())
+    {
+      case Alembic::Util::kBooleanPOD:
+      {
+          AddPropResult result = addScalarExtentOneProp<bool>
+              (iProp, extent, false, plug, attrName, numAttr, attrObj,
+               MFnNumericData::kBoolean);
+
+          if (result == INVALID) {
+              return false;
+          }
+
+          if (result == VALID_DONE) {
+              attrsList << ";" << attrName;
+              return true;
+          }
+      }
+      break;
+
+      case Alembic::Util::kUint8POD:
+      case Alembic::Util::kInt8POD:
+      {
+          AddPropResult result = addScalarExtentOneProp<Alembic::Util::int8_t>
+              (iProp, extent, 1, plug, attrName, numAttr, attrObj,
+               MFnNumericData::kByte);
+
+          if (result == INVALID) {
+              return false;
+          }
+
+          if (result == VALID_DONE) {
+              attrsList << ";" << attrName;
+              return true;
+          }
+      }
+      break;
+
+      case Alembic::Util::kInt16POD:
+      case Alembic::Util::kUint16POD:
+      {
+          AddPropResult result = addScalarExtentThreeProp<Alembic::Util::int16_t>
+              (iProp, extent, 0, plug, attrName, numAttr, attrObj,
+               MFnNumericData::kShort,
+               MFnNumericData::k2Short,
+               MFnNumericData::k3Short);
+
+          if (result == INVALID) {
+              return false;
+          }
+
+          if (result == VALID_DONE) {
+              attrsList << ";" << attrName;
+              return true;
+          }
+      }
+      break;
+
+      case Alembic::Util::kUint32POD:
+      case Alembic::Util::kInt32POD:
+      {
+          AddPropResult result = addScalarExtentThreeProp<Alembic::Util::int32_t>
+              (iProp, extent, 0, plug, attrName, numAttr, attrObj,
+               MFnNumericData::kInt,
+               MFnNumericData::k2Int,
+               MFnNumericData::k3Int);
+
+          if (result == INVALID) {
+              return false;
+          }
+
+          if (result == VALID_DONE) {
+              attrsList << ";" << attrName;
+              return true;
+          }
+      }
+      break;
+
+      case Alembic::Util::kFloat32POD:
+      {
+          AddPropResult result = addScalarExtentThreeProp<float>
+              (iProp, extent, 0.f, plug, attrName, numAttr, attrObj,
+               MFnNumericData::kFloat,
+               MFnNumericData::k2Float,
+               MFnNumericData::k3Float);
+
+          if (result == INVALID) {
+              return false;
+          }
+
+          if (result == VALID_DONE) {
+              attrsList << ";" << attrName;
+              return true;
+          }
+      }
+      break;
+
+      case Alembic::Util::kFloat64POD:
+      {
+          AddPropResult result = addScalarExtentFourProp<double>
+              (iProp, extent, 0.f, plug, attrName, numAttr, attrObj,
+               MFnNumericData::kDouble,
+               MFnNumericData::k2Double,
+               MFnNumericData::k3Double,
+               MFnNumericData::k4Double);
+
+          if (result == INVALID) {
+              return false;
+          }
+
+          if (result == VALID_DONE) {
+              attrsList << ";" << attrName;
+              return true;
+          }
+      }
+      break;
+
+      case Alembic::Util::kStringPOD:
+      {
+          if (extent != 1)
+              return false;
+
+          MFnStringData fnStringData;
+          MObject strAttrObject;
+
+          if (iProp.isConstant())
+          {
+              Alembic::Abc::IStringProperty strProp( iProp.getPtr(),
+                                                     Alembic::Abc::kWrapExisting );
+              if (!strProp.valid())
+                  return false;
+
+              if (strProp.getNumSamples() == 0)
+                  return false;
+
+              static const Alembic::Abc::ISampleSelector iss((Alembic::Abc::index_t)0);
+              std::string val = strProp.getValue(iss);
+
+              MString attrValue(val.c_str());
+              strAttrObject = fnStringData.create(attrValue);
+              if (!plug.isNull())
+              {
+                  plug.setValue(strAttrObject);
+                  attrsList << ";" << attrName;
+                  return true;
+              }
+          }
+
+          attrObj = typedAttr.create(attrName, attrName, MFnData::kString,
+                        MObject::kNullObj);
+
+          parentFn.addAttribute(attrObj,  MFnDependencyNode::kLocalDynamicAttr);
+
+          plug = parentFn.findPlug(attrName);
+          if (!plug.isNull())
+          {
+             plug.setValue(strAttrObject);
+          }
+      }
+      break;
+
+      default:
+          std::cout << "Type not yet supported.\n";
+          break;
+    }
+
+    typedAttr.setKeyable(true);
+    numAttr.setKeyable(true);
+    typedAttr.setWritable(isWritable);
+    numAttr.setWritable(isWritable);
+    typedAttr.setReadable(true);
+    numAttr.setReadable(true);
+
+    if (interp == "rgb")
+    {
+        typedAttr.setUsedAsColor(true);
+        numAttr.setUsedAsColor(true);
+    }
+
+    if ( ! parentFn.hasAttribute( attrName ) )
+    {
+        parentFn.addAttribute(attrObj,  MFnDependencyNode::kLocalDynamicAttr);
+    }
+
+    addArbAttrAndScope(iParent, iProp.getName(),
+        iProp.getMetaData().get("geoScope"), interp, extent);
+
+    plug = parentFn.findPlug(attrName);
+    if (!plug.isNull()) {
+        attrsList << ";" << attrName;
+    }
+
+    return true;
+}
+
+//=============================================================================
+
+
+std::string addProps(Alembic::Abc::ICompoundProperty & iParent, MObject & iObject,
+    bool iUnmarkedFaceVaryingColors, bool areWritable)
+{
+    // if the params CompoundProperty (.arbGeomParam or .userProperties)
+    // aren't valid, then skip
+    if (!iParent)
+        return "";
+
+    std::ostringstream attrsList;
+    std::size_t numProps = iParent.getNumProperties();
+    for (std::size_t i = 0; i < numProps; ++i)
+    {
+        const Alembic::Abc::PropertyHeader & propHeader =
+            iParent.getPropertyHeader(i);
+
+        const std::string & propName = propHeader.getName();
+
+        if (propName.empty() || propName.find('[') != std::string::npos)
+        {
+            MString warn = "Skipping oddly named property: ";
+            warn += propName.c_str();
+
+            MGlobal::displayWarning(warn);
+        }
+        // Skip attributes that we deal with elsewhere
+        else if (propName[0] != '.')
+        {
+            if (propHeader.isArray())
+            {
+                Alembic::Abc::IArrayProperty prop(iParent, propName);
+                if (prop.getNumSamples() == 0)
+                {
+                    MString warn = "Skipping property with no samples: ";
+                    warn += propName.c_str();
+
+                    MGlobal::displayWarning(warn);
+                }
+
+                if (!addArrayProp(prop, iObject, areWritable, attrsList))
+                {
+                    unsupportedWarning<Alembic::Abc::IArrayProperty>(prop);
+                }
+            }
+            else if (propHeader.isScalar())
+            {
+                Alembic::Abc::IScalarProperty prop(iParent, propName);
+                if (prop.getNumSamples() == 0)
+                {
+                    MString warn = "Skipping property with no samples: ";
+                    warn += propName.c_str();
+
+                    MGlobal::displayWarning(warn);
+                }
+
+                if (!addScalarProp(prop, iObject, areWritable, attrsList))
+                {
+                    unsupportedWarning<Alembic::Abc::IScalarProperty>(prop);
+                }
+            }
+        }
+    }
+
+    std::string result = attrsList.str();
+    // Remove the leading ';'
+    result.erase(0, 1);
+    return result;
+}
+
+//=============================================================================
+
+void readProp(double iFrame,
+              Alembic::Abc::IArrayProperty & iProp,
+              MDataHandle & iHandle)
+{
+    MObject attrObj;
+    Alembic::AbcCoreAbstract::DataType dtype = iProp.getDataType();
+    Alembic::Util::uint8_t extent = dtype.getExtent();
+
+    Alembic::AbcCoreAbstract::ArraySamplePtr samp, ceilSamp;
+
+    const SampleInfo &sampleInfo =
+      getSampleInfo(iFrame, iProp.getTimeSampling(), iProp.getNumSamples());
+    const Alembic::AbcCoreAbstract::index_t index = sampleInfo.floorIndex;
+    const Alembic::AbcCoreAbstract::index_t ceilIndex = sampleInfo.ceilIndex;
+    const double alpha = sampleInfo.alpha;
+
+    bool isScalarLike = iProp.isScalarLike() &&
+        iProp.getMetaData().get("isArray") != "1";
+
+    switch (dtype.getPod())
+    {
+        case Alembic::Util::kBooleanPOD:
+        {
+            if (!isScalarLike || extent != 1)
+            {
+                return;
+            }
+
+            iProp.get(samp, index);
+            Alembic::Util::bool_t val =
+                ((Alembic::Util::bool_t *) samp->getData())[0];
+            iHandle.setBool(val != false);
+        }
+        break;
+
+        case Alembic::Util::kUint8POD:
+        case Alembic::Util::kInt8POD:
+        {
+            if (!isScalarLike || extent != 1)
+            {
+                return;
+            }
+
+            Alembic::Util::int8_t val;
+
+            if (index != ceilIndex && alpha != 0.0)
+            {
+                iProp.get(samp, index);
+                iProp.get(ceilSamp, ceilIndex);
+                Alembic::Util::int8_t lo =
+                    ((Alembic::Util::int8_t *) samp->getData())[0];
+                Alembic::Util::int8_t hi =
+                    ((Alembic::Util::int8_t *) ceilSamp->getData())[0];
+                val = simpleLerp<Alembic::Util::int8_t>(alpha, lo, hi);
+            }
+            else
+            {
+                iProp.get(samp, Alembic::Abc::ISampleSelector(index));
+                val = ((Alembic::Util::int8_t *) samp->getData())[0];
+            }
+
+            iHandle.setChar(val);
+        }
+        break;
+
+        case Alembic::Util::kInt16POD:
+        case Alembic::Util::kUint16POD:
+        {
+            Alembic::Util::int16_t val[3];
+
+            if (index != ceilIndex && alpha != 0.0)
+            {
+                iProp.get(samp, Alembic::Abc::ISampleSelector(index));
+                iProp.get(ceilSamp, Alembic::Abc::ISampleSelector(ceilIndex));
+                for (Alembic::Util::uint8_t i = 0; i < extent; ++i)
+                {
+                     val[i] = simpleLerp<Alembic::Util::int16_t>(alpha,
+                        ((Alembic::Util::int16_t *)samp->getData())[i],
+                        ((Alembic::Util::int16_t *)ceilSamp->getData())[i]);
+                }
+            }
+            else
+            {
+                iProp.get(samp, Alembic::Abc::ISampleSelector(index));
+                for (Alembic::Util::uint8_t i = 0; i < extent; ++i)
+                {
+                     val[i] = ((Alembic::Util::int16_t *)samp->getData())[i];
+                }
+            }
+
+            if (extent == 1)
+            {
+                iHandle.setShort(val[0]);
+            }
+            else if (extent == 2)
+            {
+                iHandle.set2Short(val[0], val[1]);
+            }
+            else if (extent == 3)
+            {
+                iHandle.set3Short(val[0], val[1], val[2]);
+            }
+        }
+        break;
+
+        case Alembic::Util::kUint32POD:
+        case Alembic::Util::kInt32POD:
+        {
+            if (isScalarLike && extent < 4)
+            {
+                Alembic::Util::int32_t val[3];
+
+                if (index != ceilIndex && alpha != 0.0)
+                {
+                    iProp.get(samp, Alembic::Abc::ISampleSelector(index));
+                    iProp.get(ceilSamp,
+                        Alembic::Abc::ISampleSelector(ceilIndex));
+                    for (Alembic::Util::uint8_t i = 0; i < extent; ++i)
+                    {
+                         val[i] = simpleLerp<Alembic::Util::int32_t>(alpha,
+                            ((Alembic::Util::int32_t *)samp->getData())[i],
+                            ((Alembic::Util::int32_t *)ceilSamp->getData())[i]);
+                    }
+                }
+                else
+                {
+                    iProp.get(samp, Alembic::Abc::ISampleSelector(index));
+                    for (Alembic::Util::uint8_t i = 0; i < extent; ++i)
+                    {
+                         val[i] =
+                            ((Alembic::Util::int32_t *) samp->getData())[i];
+                    }
+                }
+
+                if (extent == 1)
+                {
+                    iHandle.setInt(val[0]);
+                }
+                else if (extent == 2)
+                {
+                    iHandle.set2Int(val[0], val[1]);
+                }
+                else if (extent == 3)
+                {
+                    iHandle.set3Int(val[0], val[1], val[2]);
+                }
+            }
+            else
+            {
+                MFnIntArrayData fnData;
+                iProp.get(samp, Alembic::Abc::ISampleSelector(index));
+
+                if (alpha != 0.0 && index != ceilIndex)
+                {
+                    iProp.get(ceilSamp,
+                        Alembic::Abc::ISampleSelector(ceilIndex));
+
+                    MIntArray arr((int *) samp->getData(),
+                        static_cast<unsigned int>(samp->size()));
+                    std::size_t sampSize = samp->size();
+
+                    // size is different don't lerp
+                    if (sampSize != ceilSamp->size())
+                    {
+                        attrObj = fnData.create(arr);
+                    }
+                    else
+                    {
+                        int * hi = (int *) ceilSamp->getData();
+                        for (unsigned int i = 0; i < sampSize; ++i)
+                        {
+                            arr[i] = simpleLerp<int>(alpha, arr[i], hi[i]);
+                        }
+                    }
+                    attrObj = fnData.create(arr);
+                }
+                else
+                {
+                    MIntArray arr((int *) samp->getData(),
+                        static_cast<unsigned int>(samp->size()));
+                    attrObj = fnData.create(arr);
+                }
+            }
+        }
+        break;
+
+        case Alembic::Util::kFloat32POD:
+        {
+            if (isScalarLike && extent < 4)
+            {
+                float val[3];
+
+                if (index != ceilIndex && alpha != 0.0)
+                {
+                    iProp.get(samp, Alembic::Abc::ISampleSelector(index));
+                    iProp.get(ceilSamp,
+                        Alembic::Abc::ISampleSelector(ceilIndex));
+                    for (Alembic::Util::uint8_t i = 0; i < extent; ++i)
+                    {
+                        val[i] = simpleLerp<float>(alpha,
+                            ((float *)samp->getData())[i],
+                            ((float *)ceilSamp->getData())[i]);
+                    }
+                }
+                else
+                {
+                    iProp.get(samp, Alembic::Abc::ISampleSelector(index));
+                    for (Alembic::Util::uint8_t i = 0; i < extent; ++i)
+                    {
+                        val[i] = ((float *)samp->getData())[i];
+                    }
+                }
+
+                if (extent == 1)
+                {
+                    iHandle.setFloat(val[0]);
+                }
+                else if (extent == 2)
+                {
+                    iHandle.set2Float(val[0], val[1]);
+                }
+                else if (extent == 3)
+                {
+                    iHandle.set3Float(val[0], val[1], val[2]);
+                }
+            }
+            else
+            {
+                std::string interp = iProp.getMetaData().get("interpretation");
+
+                if ((extent == 2 || extent == 3) && (interp == "normal" ||
+                    interp == "vector" || interp == "rgb"))
+                {
+                    MFnVectorArrayData fnData;
+                    iProp.get(samp, Alembic::Abc::ISampleSelector(index));
+                    unsigned int sampSize = (unsigned int)samp->size();
+                    MVectorArray arr(sampSize);
+                    MVector vec;
+
+                    if (alpha != 0.0 && index != ceilIndex)
+                    {
+                        iProp.get(ceilSamp,
+                            Alembic::Abc::ISampleSelector(ceilIndex));
+
+                        // size is different don't lerp
+                        if (sampSize != ceilSamp->size())
+                        {
+                            float * vals = (float *) samp->getData();
+                            for (unsigned int i = 0; i < sampSize; ++i)
+                            {
+                                vec.x = vals[extent*i];
+                                vec.y = vals[extent*i+1];
+
+                                if (extent == 3)
+                                {
+                                    vec.z = vals[extent*i+2];
+                                }
+                                arr[i] = vec;
+                            }
+
+                            attrObj = fnData.create(arr);
+                        }
+                        else
+                        {
+                            float * lo = (float *) samp->getData();
+                            float * hi = (float *) ceilSamp->getData();
+
+                            for (unsigned int i = 0; i < sampSize; ++i)
+                            {
+                                vec.x = simpleLerp<double>(alpha,
+                                    lo[extent*i], hi[extent*i]);
+
+                                vec.y = simpleLerp<double>(alpha,
+                                    lo[extent*i+1], hi[extent*i+1]);
+
+                                if (extent == 3)
+                                {
+                                    vec.z = simpleLerp<double>(alpha,
+                                        lo[extent*i+2], hi[extent*i+2]);
+                                }
+                                arr[i] = vec;
+                            }
+                        }
+                        attrObj = fnData.create(arr);
+                    }
+                    else
+                    {
+                        float * vals = (float *) samp->getData();
+                        for (unsigned int i = 0; i < sampSize; ++i)
+                        {
+                            vec.x = vals[extent*i];
+                            vec.y = vals[extent*i+1];
+
+                            if (extent == 3)
+                            {
+                                vec.z = vals[extent*i+2];
+                            }
+                            arr[i] = vec;
+                        }
+                        attrObj = fnData.create(arr);
+                    }
+                }
+                else if (interp == "point" && (extent == 2 || extent == 3))
+                {
+                    MFnPointArrayData fnData;
+                    iProp.get(samp, Alembic::Abc::ISampleSelector(index));
+
+                    unsigned int sampSize = (unsigned int)samp->size();
+                    MPointArray arr(sampSize);
+                    MPoint pt;
+
+                    if (alpha != 0.0 && index != ceilIndex)
+                    {
+                        iProp.get(ceilSamp,
+                            Alembic::Abc::ISampleSelector(ceilIndex));
+
+                        // size is different don't lerp
+                        if (sampSize != ceilSamp->size())
+                        {
+                            float * vals = (float *) samp->getData();
+                            for (unsigned int i = 0; i < sampSize; ++i)
+                            {
+                                pt.x = vals[extent*i];
+                                pt.y = vals[extent*i+1];
+
+                                if (extent == 3)
+                                {
+                                    pt.z = vals[extent*i+2];
+                                }
+                                arr[i] = pt;
+                            }
+
+                            attrObj = fnData.create(arr);
+                        }
+                        else
+                        {
+                            float * lo = (float *) samp->getData();
+                            float * hi = (float *) ceilSamp->getData();
+
+                            for (unsigned int i = 0; i < sampSize; ++i)
+                            {
+                                pt.x = simpleLerp<double>(alpha,
+                                    lo[extent*i], hi[extent*i]);
+
+                                pt.y = simpleLerp<double>(alpha,
+                                    lo[extent*i+1], hi[extent*i+1]);
+
+                                if (extent == 3)
+                                {
+                                    pt.z = simpleLerp<double>(alpha,
+                                        lo[extent*i+2], hi[extent*i+2]);
+                                }
+                                arr[i] = pt;
+                            }
+                            attrObj = fnData.create(arr);
+                        }
+                    }
+                    else
+                    {
+                        float * vals = (float *) samp->getData();
+                        for (unsigned int i = 0; i < sampSize; ++i)
+                        {
+                            pt.x = vals[extent*i];
+                            pt.y = vals[extent*i+1];
+
+                            if (extent == 3)
+                            {
+                                pt.z = vals[extent*i+2];
+                            }
+                            arr[i] = pt;
+                        }
+                        attrObj = fnData.create(arr);
+                    }
+                }
+                else
+                {
+                    MFnDoubleArrayData fnData;
+                    iProp.get(samp, Alembic::Abc::ISampleSelector(index));
+
+                    if (alpha != 0.0 && index != ceilIndex)
+                    {
+                        iProp.get(ceilSamp,
+                            Alembic::Abc::ISampleSelector(ceilIndex));
+
+                        MDoubleArray arr((float *) samp->getData(),
+                            static_cast<unsigned int>(samp->size()));
+                        std::size_t sampSize = samp->size();
+
+                        // size is different don't lerp
+                        if (sampSize != ceilSamp->size())
+                        {
+                            attrObj = fnData.create(arr);
+                        }
+                        else
+                        {
+                            float * hi = (float *) ceilSamp->getData();
+                            for (unsigned int i = 0; i < sampSize; ++i)
+                            {
+                                arr[i] = simpleLerp<double>(alpha, arr[i],
+                                    hi[i]);
+                            }
+                        }
+                        attrObj = fnData.create(arr);
+                    }
+                    else
+                    {
+                        MDoubleArray arr((float *) samp->getData(),
+                            static_cast<unsigned int>(samp->size()));
+                        attrObj = fnData.create(arr);
+                    }
+                }
+            }
+        }
+        break;
+
+        case Alembic::Util::kFloat64POD:
+        {
+            // need to differentiate between vectors, points, and color array?
+            if (isScalarLike && extent < 5)
+            {
+                double val[4];
+
+                if (index != ceilIndex && alpha != 0.0)
+                {
+                    iProp.get(samp, Alembic::Abc::ISampleSelector(index));
+
+                    iProp.get(ceilSamp,
+                        Alembic::Abc::ISampleSelector(ceilIndex));
+                    for (Alembic::Util::uint8_t i = 0; i < extent; ++i)
+                    {
+                         val[i] = simpleLerp<double>(alpha,
+                            ((double *)(samp->getData()))[i],
+                            ((double *)(ceilSamp->getData()))[i]);
+                    }
+                }
+                else
+                {
+                    iProp.get(samp, Alembic::Abc::ISampleSelector(index));
+                    for (Alembic::Util::uint8_t i = 0; i < extent; ++i)
+                    {
+                         val[i] = ((double *)(samp->getData()))[i];
+                    }
+                }
+
+                if (extent == 1)
+                {
+                    iHandle.setDouble(val[0]);
+                }
+                else if (extent == 2)
+                {
+                    iHandle.set2Double(val[0], val[1]);
+                }
+                else if (extent == 3)
+                {
+                    iHandle.set3Double(val[0], val[1], val[2]);
+                }
+                else if (extent == 4)
+                {
+                    MFnNumericData numData;
+                    numData.create(MFnNumericData::k4Double);
+                    numData.setData4Double(val[0], val[1], val[2], val[3]);
+                    iHandle.setMObject(numData.object());
+                }
+            }
+            else
+            {
+                std::string interp = iProp.getMetaData().get("interpretation");
+
+                if ((extent == 2 || extent == 3) && (interp == "normal" ||
+                    interp == "vector" || interp == "rgb"))
+                {
+                    MFnVectorArrayData fnData;
+                    iProp.get(samp, Alembic::Abc::ISampleSelector(index));
+                    unsigned int sampSize = (unsigned int)samp->size();
+                    MVectorArray arr(sampSize);
+                    MVector vec;
+
+                    if (alpha != 0.0 && index != ceilIndex)
+                    {
+                        iProp.get(ceilSamp,
+                            Alembic::Abc::ISampleSelector(ceilIndex));
+
+                        // size is different don't lerp
+                        if (sampSize != ceilSamp->size())
+                        {
+                            double * vals = (double *) samp->getData();
+                            for (unsigned int i = 0; i < sampSize; ++i)
+                            {
+                                vec.x = vals[extent*i];
+                                vec.y = vals[extent*i+1];
+
+                                if (extent == 3)
+                                {
+                                    vec.z = vals[extent*i+2];
+                                }
+                                arr[i] = vec;
+                            }
+
+                            attrObj = fnData.create(arr);
+                        }
+                        else
+                        {
+                            double * lo = (double *) samp->getData();
+                            double * hi = (double *) ceilSamp->getData();
+
+                            for (unsigned int i = 0; i < sampSize; ++i)
+                            {
+                                vec.x = simpleLerp<double>(alpha,
+                                    lo[extent*i], hi[extent*i]);
+
+                                vec.y = simpleLerp<double>(alpha,
+                                    lo[extent*i+1], hi[extent*i+1]);
+
+                                if (extent == 3)
+                                {
+                                    vec.z = simpleLerp<double>(alpha,
+                                        lo[extent*i+2], hi[extent*i+2]);
+                                }
+                                arr[i] = vec;
+                            }
+                        }
+                        attrObj = fnData.create(arr);
+                    }
+                    else
+                    {
+                        double * vals = (double *) samp->getData();
+                        for (unsigned int i = 0; i < sampSize; ++i)
+                        {
+                            vec.x = vals[extent*i];
+                            vec.y = vals[extent*i+1];
+
+                            if (extent == 3)
+                            {
+                                vec.z = vals[extent*i+2];
+                            }
+                            arr[i] = vec;
+                        }
+                        attrObj = fnData.create(arr);
+                    }
+                }
+                else if (interp == "point" && (extent == 2 || extent == 3))
+                {
+                    MFnPointArrayData fnData;
+                    iProp.get(samp, Alembic::Abc::ISampleSelector(index));
+                    unsigned int sampSize = (unsigned int)samp->size();
+                    MPointArray arr(sampSize);
+                    MPoint pt;
+
+                    if (alpha != 0.0 && index != ceilIndex)
+                    {
+                        iProp.get(ceilSamp,
+                            Alembic::Abc::ISampleSelector(ceilIndex));
+
+                        // size is different don't lerp
+                        if (sampSize != ceilSamp->size())
+                        {
+                            double * vals = (double *) samp->getData();
+                            for (unsigned int i = 0; i < sampSize; ++i)
+                            {
+                                pt.x = vals[extent*i];
+                                pt.y = vals[extent*i+1];
+
+                                if (extent == 3)
+                                {
+                                    pt.z = vals[extent*i+2];
+                                }
+                                arr[i] = pt;
+                            }
+
+                            attrObj = fnData.create(arr);
+                        }
+                        else
+                        {
+                            double * lo = (double *) samp->getData();
+                            double * hi = (double *) ceilSamp->getData();
+
+                            for (unsigned int i = 0; i < sampSize; ++i)
+                            {
+                                pt.x = simpleLerp<double>(alpha,
+                                    lo[extent*i], hi[extent*i]);
+
+                                pt.y = simpleLerp<double>(alpha,
+                                    lo[extent*i+1], hi[extent*i+1]);
+
+                                if (extent == 3)
+                                {
+                                    pt.z = simpleLerp<double>(alpha,
+                                        lo[extent*i+2], hi[extent*i+2]);
+                                }
+                                arr[i] = pt;
+                            }
+                            attrObj = fnData.create(arr);
+                        }
+                    }
+                    else
+                    {
+                        double * vals = (double *) samp->getData();
+                        for (unsigned int i = 0; i < sampSize; ++i)
+                        {
+                            pt.x = vals[extent*i];
+                            pt.y = vals[extent*i+1];
+
+                            if (extent == 3)
+                            {
+                                pt.z = vals[extent*i+2];
+                            }
+                            arr[i] = pt;
+                        }
+                        attrObj = fnData.create(arr);
+                    }
+                }
+                else
+                {
+                    MFnDoubleArrayData fnData;
+                    iProp.get(samp, Alembic::Abc::ISampleSelector(index));
+
+                    if (alpha != 0.0 && index != ceilIndex)
+                    {
+                        iProp.get(ceilSamp,
+                            Alembic::Abc::ISampleSelector(ceilIndex));
+
+                        MDoubleArray arr((double *) samp->getData(),
+                            static_cast<unsigned int>(samp->size()));
+                        std::size_t sampSize = samp->size();
+
+                        // size is different don't lerp
+                        if (sampSize != ceilSamp->size())
+                        {
+                            attrObj = fnData.create(arr);
+                        }
+                        else
+                        {
+                            double * hi = (double *) ceilSamp->getData();
+                            for (unsigned int i = 0; i < sampSize; ++i)
+                            {
+                                arr[i] = simpleLerp<double>(alpha, arr[i],
+                                    hi[i]);
+                            }
+                        }
+                        attrObj = fnData.create(arr);
+                    }
+                    else
+                    {
+                        MDoubleArray arr((double *) samp->getData(),
+                            static_cast<unsigned int>(samp->size()));
+                        attrObj = fnData.create(arr);
+                    }
+                }
+            }
+        }
+        break;
+
+        // MFnStringArrayData
+        case Alembic::Util::kStringPOD:
+        {
+            if (isScalarLike && extent == 1)
+            {
+                iProp.get(samp, Alembic::Abc::ISampleSelector(index));
+                iHandle.setString(
+                    ((Alembic::Util::string *)samp->getData())[0].c_str());
+            }
+            else
+            {
+                MFnStringArrayData fnData;
+                iProp.get(samp, Alembic::Abc::ISampleSelector(index));
+
+                unsigned int sampSize = (unsigned int)samp->size();
+                MStringArray arr;
+                arr.setLength(sampSize);
+                attrObj = fnData.create(arr);
+                Alembic::Util::string * strData =
+                    (Alembic::Util::string *) samp->getData();
+
+                for (unsigned int i = 0; i < sampSize; ++i)
+                {
+                    arr[i] = strData[i].c_str();
+                }
+            }
+        }
+        break;
+
+        // MFnStringArrayData
+        case Alembic::Util::kWstringPOD:
+        {
+            if (isScalarLike && extent == 1)
+            {
+                iProp.get(samp, Alembic::Abc::ISampleSelector(index));
+                iHandle.setString(
+                    ((Alembic::Util::wstring *)samp->getData())[0].c_str());
+            }
+            else
+            {
+                MFnStringArrayData fnData;
+                iProp.get(samp, Alembic::Abc::ISampleSelector(index));
+
+                unsigned int sampSize = (unsigned int)samp->size();
+                MStringArray arr;
+                arr.setLength(sampSize);
+                attrObj = fnData.create(arr);
+                Alembic::Util::wstring * strData =
+                    (Alembic::Util::wstring *) samp->getData();
+
+                for (unsigned int i = 0; i < sampSize; ++i)
+                {
+                    arr[i] = (wchar_t *)strData[i].c_str();
+                }
+            }
+        }
+        break;
+
+        default:
+        break;
+    }
+
+    if (!attrObj.isNull())
+        iHandle.set(attrObj);
+}
+
+void readProp(double iFrame,
+              Alembic::Abc::IScalarProperty & iProp,
+              MDataHandle & iHandle)
+{
+    MObject attrObj;
+    Alembic::AbcCoreAbstract::DataType dtype = iProp.getDataType();
+    Alembic::Util::uint8_t extent = dtype.getExtent();
+
+    const SampleInfo &sampleInfo =
+      getSampleInfo(iFrame, iProp.getTimeSampling(), iProp.getNumSamples());
+    const Alembic::AbcCoreAbstract::index_t index = sampleInfo.floorIndex;
+    const Alembic::AbcCoreAbstract::index_t ceilIndex = sampleInfo.ceilIndex;
+    const double alpha = sampleInfo.alpha;
+
+    switch (dtype.getPod())
+    {
+        case Alembic::Util::kBooleanPOD:
+        {
+            if (extent != 1)
+                return;
+
+            Alembic::Util::bool_t val;
+            iProp.get(&val, index);
+
+            iHandle.setBool(val != false);
+        }
+        break;
+
+        case Alembic::Util::kUint8POD:
+        case Alembic::Util::kInt8POD:
+        {
+            if (extent != 1)
+                return;
+
+            Alembic::Util::int8_t val;
+
+            if (index != ceilIndex && alpha != 0.0)
+            {
+                Alembic::Util::int8_t lo;
+                Alembic::Util::int8_t hi;
+
+                iProp.get(&lo, index);
+                iProp.get(&hi, ceilIndex);
+                val = simpleLerp<Alembic::Util::int8_t>(alpha, lo, hi);
+            }
+            else
+            {
+                iProp.get(&val, index);
+            }
+
+            iHandle.setChar(val);
+        }
+        break;
+
+        case Alembic::Util::kInt16POD:
+        case Alembic::Util::kUint16POD:
+        {
+            Alembic::Util::int16_t val[3];
+
+            if (index != ceilIndex && alpha != 0.0)
+            {
+                Alembic::Util::int16_t lo[3];
+                Alembic::Util::int16_t hi[3];
+
+                iProp.get(lo, index);
+                iProp.get(hi, ceilIndex);
+
+                for (Alembic::Util::uint8_t i = 0; i < extent; ++i)
+                {
+                    val[i] = simpleLerp<Alembic::Util::int16_t>(alpha,
+                                                                lo[i],
+                                                                hi[i]);
+                }
+            }
+            else
+            {
+                iProp.get(val, index);
+            }
+
+            if (extent == 1)
+            {
+                iHandle.setShort(val[0]);
+            }
+            else if (extent == 2)
+            {
+                iHandle.set2Short(val[0], val[1]);
+            }
+            else if (extent == 3)
+            {
+                iHandle.set3Short(val[0], val[1], val[2]);
+            }
+        }
+        break;
+
+        case Alembic::Util::kUint32POD:
+        case Alembic::Util::kInt32POD:
+        {
+            if (extent < 4)
+            {
+                Alembic::Util::int32_t val[3];
+
+                if (index != ceilIndex && alpha != 0.0)
+                {
+                    Alembic::Util::int32_t lo[3];
+                    Alembic::Util::int32_t hi[3];
+
+                    iProp.get(lo, index);
+                    iProp.get(hi, ceilIndex);
+
+                    for (Alembic::Util::uint8_t i = 0; i < extent; ++i)
+                    {
+                         val[i] = simpleLerp<Alembic::Util::int32_t>(alpha,
+                                                                     lo[i],
+                                                                     hi[i]);
+                    }
+                }
+                else
+                {
+                    iProp.get(val, index);
+                }
+
+                if (extent == 1)
+                {
+                    iHandle.setInt(val[0]);
+                }
+                else if (extent == 2)
+                {
+                    iHandle.set2Int(val[0], val[1]);
+                }
+                else if (extent == 3)
+                {
+                    iHandle.set3Int(val[0], val[1], val[2]);
+                }
+            }
+        }
+        break;
+
+        case Alembic::Util::kFloat32POD:
+        {
+            if (extent < 4)
+            {
+                float val[3];
+
+                if (index != ceilIndex && alpha != 0.0)
+                {
+                    float lo[3];
+                    float hi[3];
+
+                    iProp.get(lo, index);
+                    iProp.get(hi, ceilIndex);
+
+                    for (Alembic::Util::uint8_t i = 0; i < extent; ++i)
+                        val[i] = simpleLerp<float>(alpha, lo[i], hi[i]);
+                }
+                else
+                {
+                    iProp.get(val, index);
+                }
+
+                if (extent == 1)
+                {
+                    iHandle.setFloat(val[0]);
+                }
+                else if (extent == 2)
+                {
+                    iHandle.set2Float(val[0], val[1]);
+                }
+                else if (extent == 3)
+                {
+                    iHandle.set3Float(val[0], val[1], val[2]);
+                }
+            }
+        }
+        break;
+
+        case Alembic::Util::kFloat64POD:
+        {
+            // need to differentiate between vectors, points, and color array?
+            if (extent < 5)
+            {
+                double val[4];
+
+                if (index != ceilIndex && alpha != 0.0)
+                {
+                    double lo[4];
+                    double hi[4];
+
+                    iProp.get(lo, index);
+                    iProp.get(hi, index);
+
+                    for (Alembic::Util::uint8_t i = 0; i < extent; ++i)
+                        val[i] = simpleLerp<double>(alpha, lo[i], hi[i]);
+                }
+                else
+                {
+                    iProp.get(val, index);
+                }
+
+                if (extent == 1)
+                {
+                    iHandle.setDouble(val[0]);
+                }
+                else if (extent == 2)
+                {
+                    iHandle.set2Double(val[0], val[1]);
+                }
+                else if (extent == 3)
+                {
+                    iHandle.set3Double(val[0], val[1], val[2]);
+                }
+                else if (extent == 4)
+                {
+                    MFnNumericData numData;
+                    numData.create(MFnNumericData::k4Double);
+                    numData.setData4Double(val[0], val[1], val[2], val[3]);
+                    iHandle.setMObject(numData.object());
+                }
+            }
+        }
+        break;
+
+        // MFnStringArrayData
+        case Alembic::Util::kStringPOD:
+        {
+            if (extent == 1)
+            {
+                Alembic::Abc::IStringProperty strProp( iProp.getPtr(),
+                                                       Alembic::Abc::kWrapExisting );
+                iHandle.setString(strProp.getValue(index).c_str());
+            }
+        }
+        break;
+
+        // MFnStringArrayData
+        case Alembic::Util::kWstringPOD:
+        {
+            if (extent == 1)
+            {
+                Alembic::Abc::IWstringProperty strProp( iProp.getPtr(),
+                                                        Alembic::Abc::kWrapExisting );
+                iHandle.setString(strProp.getValue(index).c_str());
+            }
+        }
+        break;
+
+        default:
+        break;
+    }
+
+    if (!attrObj.isNull())
+        iHandle.set(attrObj);
+}
+
+void readProps(double iFrame,
+              Alembic::Abc::ICompoundProperty & iParent,
+              MDataBlock & iDataBlock,
+              MObject & iNode)
+{
+    // if the params CompoundProperty (.arbGeomParam or .userProperties)
+    // aren't valid, then skip
+    if (!iParent)
+        return;
+
+    MStatus status;
+    MFnDependencyNode depNode(iNode, &status);
+    if (status != MStatus::kSuccess) {
+        MGlobal::displayWarning("Unable to read properties");
+        return;
+    }
+
+    std::size_t numProps = iParent.getNumProperties();
+    for (std::size_t i = 0; i < numProps; ++i)
+    {
+        const Alembic::Abc::PropertyHeader & propHeader =
+            iParent.getPropertyHeader(i);
+
+        const std::string & propName = propHeader.getName();
+
+        if (propName.empty() || propName.find('[') != std::string::npos)
+        {
+            MString warn = "Skipping oddly named property: ";
+            warn += propName.c_str();
+
+            MGlobal::displayWarning(warn);
+            continue;
+        }
+
+        // Skip attributes that we deal with elsewhere
+        if (propName[0] == '.') {
+          continue;
+        }
+
+        MPlug plug = depNode.findPlug(propName.c_str(), true, &status);
+        if (status != MStatus::kSuccess) {
+            MGlobal::displayWarning("Skipping new property " + depNode.name() + "." + MString(propName.c_str()));
+            continue;
+        }
+
+        MDataHandle handle = iDataBlock.outputValue(plug, &status);
+        if (status != MStatus::kSuccess) {
+            MGlobal::displayWarning("Unable to get data block!");
+            continue;
+        }
+
+        if (propHeader.isArray())
+        {
+            Alembic::Abc::IArrayProperty prop(iParent, propName);
+            if (prop.getNumSamples() == 0)
+            {
+                MString warn = "Skipping property with no samples: ";
+                warn += propName.c_str();
+
+                MGlobal::displayWarning(warn);
+            }
+
+            readProp(iFrame, prop, handle);
+        }
+        else if (propHeader.isScalar())
+        {
+            Alembic::Abc::IScalarProperty prop(iParent, propName);
+            if (prop.getNumSamples() == 0)
+            {
+                MString warn = "Skipping property with no samples: ";
+                warn += propName.c_str();
+
+                MGlobal::displayWarning(warn);
+            }
+
+            readProp(iFrame, prop, handle);
+        }
+    }
+}

--- a/Maya/AttributesReading.h
+++ b/Maya/AttributesReading.h
@@ -1,0 +1,148 @@
+//-*****************************************************************************
+//
+// Copyright (c) 2009-2012,
+//  Sony Pictures Imageworks, Inc. and
+//  Industrial Light & Magic, a division of Lucasfilm Entertainment Company Ltd.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+// *       Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// *       Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+// *       Neither the name of Sony Pictures Imageworks, nor
+// Industrial Light & Magic nor the names of their contributors may be used
+// to endorse or promote products derived from this software without specific
+// prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//-*****************************************************************************
+
+#ifndef ABCIMPORT_NODE_ITERATOR_HELPER_H_
+#define ABCIMPORT_NODE_ITERATOR_HELPER_H_
+
+#include <Alembic/Abc/IArrayProperty.h>
+#include <Alembic/Abc/IScalarProperty.h>
+#include <Alembic/Abc/IObject.h>
+
+#include <Alembic/AbcGeom/ICamera.h>
+#include <Alembic/AbcGeom/ICurves.h>
+#include <Alembic/AbcGeom/INuPatch.h>
+#include <Alembic/AbcGeom/IPoints.h>
+#include <Alembic/AbcGeom/IPolyMesh.h>
+#include <Alembic/AbcGeom/ISubD.h>
+#include <Alembic/AbcGeom/IXform.h>
+
+#include <maya/MObject.h>
+#include <maya/MPlug.h>
+#include <maya/MDataHandle.h>
+#include <maya/MArrayDataHandle.h>
+#include <maya/MString.h>
+#include <maya/MFnNumericAttribute.h>
+#include <maya/MFnNumericData.h>
+
+#include <vector>
+#include <string>
+
+// mArray or mScalar will be valid, mObj will be valid for those situations
+// where the property can't be validly read, unless the object stays in scope.
+struct Prop
+{
+    Alembic::Abc::IArrayProperty mArray;
+    Alembic::Abc::IScalarProperty mScalar;
+};
+
+std::string addProps(Alembic::Abc::ICompoundProperty & iParent, MObject & iObject,
+              bool iUnmarkedFaceVaryingColors, bool areWritable);
+
+bool addArrayProp(Alembic::Abc::IArrayProperty & iProp, MObject & iParent,
+    bool isWritable,
+    std::ostringstream &attrsList);
+bool addScalarProp(Alembic::Abc::IScalarProperty & iProp, MObject & iParent,
+    bool isWritable,
+    std::ostringstream &attrsList);
+
+enum AddPropResult
+{
+    INVALID = 0,
+    VALID_DONE = 1,
+    VALID_NOTDONE = 2
+};
+
+//
+// Three possible return states, invalid, valid and done (attribute
+// already existed and has been updated), valid and not done (new
+// attribute needs calling method to continue).
+//
+
+//
+// Avoiding some duplicated code with these templated versions.
+//
+template<class PODTYPE>
+AddPropResult
+addScalarExtentOneProp(Alembic::Abc::IScalarProperty& iProp,
+                       Alembic::Util::uint8_t extent,
+                       PODTYPE defaultVal,
+                       MPlug& plug,
+                       MString& attrName,
+                       MFnNumericAttribute& numAttr,
+                       MObject& attrObj,
+                       MFnNumericData::Type type);
+
+template <class PODTYPE>
+AddPropResult
+addScalarExtentThreeProp(Alembic::Abc::IScalarProperty& iProp,
+                         Alembic::Util::uint8_t extent,
+                         PODTYPE defaultVal,
+                         MPlug& plug,
+                         MString& attrName,
+                         MFnNumericAttribute& numAttr,
+                         MObject& attrObj,
+                         MFnNumericData::Type type1,
+                         MFnNumericData::Type type2,
+                         MFnNumericData::Type type3);
+
+template <class PODTYPE>
+AddPropResult
+addScalarExtentFourProp(Alembic::Abc::IScalarProperty& iProp,
+                        Alembic::Util::uint8_t extent,
+                        PODTYPE defaultVal,
+                        MPlug& plug,
+                        MString& attrName,
+                        MFnNumericAttribute& numAttr,
+                        MObject& attrObj,
+                        MFnNumericData::Type type1,
+                        MFnNumericData::Type type2,
+                        MFnNumericData::Type type3,
+                        MFnNumericData::Type type4);
+
+void readProp(double iFrame,
+              Alembic::Abc::IArrayProperty & iProp,
+              MDataHandle & iHandle);
+
+void readProp(double iFrame,
+              Alembic::Abc::IScalarProperty & iProp,
+              MDataHandle & iHandle);
+
+void readProps(double iFrame,
+               Alembic::Abc::ICompoundProperty & iParent,
+               MDataBlock & iDataBlock,
+               MObject & iNode);
+
+#endif  // ABCIMPORT_NODE_ITERATOR_HELPER_H_

--- a/Maya/AttributesWriter.cpp
+++ b/Maya/AttributesWriter.cpp
@@ -1,0 +1,2098 @@
+//-*****************************************************************************
+//
+// Copyright (c) 2009-2013,
+//  Sony Pictures Imageworks Inc. and
+//  Industrial Light & Magic, a division of Lucasfilm Entertainment Company Ltd.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+// *       Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// *       Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+// *       Neither the name of Sony Pictures Imageworks, nor
+// Industrial Light & Magic, nor the names of their contributors may be used
+// to endorse or promote products derived from this software without specific
+// prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//-*****************************************************************************
+#include "stdafx.h"
+
+#include "AttributesWriter.h"
+#include "MayaUtility.h"
+
+#include <maya/MFnDoubleArrayData.h>
+#include <maya/MFnFloatArrayData.h>
+#include <maya/MFnPointArrayData.h>
+#include <maya/MFnStringArrayData.h>
+#include <maya/MFnVectorArrayData.h>
+
+//namespace Abc = Alembic::Abc;
+namespace AbcGeom = Alembic::AbcGeom;
+//namespace AbcA = Alembic::AbcCoreAbstract;
+
+namespace {
+
+static const char * cAttrScope = "_AbcGeomScope";
+static const char * cAttrType  = "_AbcType";
+
+// returns true if a plug is of a simple numeric data type
+bool isDataAttr(const MPlug & iParent)
+{
+    MObject obj = iParent.asMObject();
+    switch (obj.apiType())
+    {
+        case MFn::kData2Double:
+        case MFn::kData3Double:
+        case MFn::kData4Double:
+        case MFn::kData2Float:
+        case MFn::kData3Float:
+        case MFn::kData2Int:
+        case MFn::kData3Int:
+        case MFn::kData2Short:
+        case MFn::kData3Short:
+        case MFn::kStringData:
+        case MFn::kStringArrayData:
+        case MFn::kFloatVectorArrayData:
+        case MFn::kVectorArrayData:
+        case MFn::kFloatArrayData:
+        case MFn::kDoubleArrayData:
+        case MFn::kIntArrayData:
+        case MFn::kPointArrayData:
+        case MFn::kUInt64ArrayData:
+            return true;
+
+        default:
+            return false;
+    }
+    return false;
+}
+
+AbcGeom::GeometryScope strToScope(MString iStr)
+{
+    iStr.toLowerCase();
+    if (iStr == "vtx")
+    {
+        return AbcGeom::kVertexScope;
+    }
+    else if (iStr == "fvr")
+    {
+        return AbcGeom::kFacevaryingScope;
+    }
+    else if (iStr == "uni")
+    {
+        return AbcGeom::kUniformScope;
+    }
+    else if (iStr == "var")
+    {
+        return AbcGeom::kVaryingScope;
+    }
+
+    return AbcGeom::kConstantScope;
+}
+
+// returns true if the string ends with _AbcGeomScope or _AbcType
+bool endsWithArbAttr(const std::string & iStr)
+{
+    size_t len = iStr.size();
+
+    return (len >= 13 && iStr.compare(len - 13, 13, cAttrScope) == 0) ||
+        (len >= 8 && iStr.compare(len - 8, 8, cAttrType) == 0);
+}
+
+void createUserPropertyFromNumeric(MFnNumericData::Type iType,
+                                   const MObject& iAttr,
+                                   const MPlug& iPlug,
+                                   Abc::OCompoundProperty & iParent,
+                                   Alembic::Util::uint32_t iTimeIndex,
+                                   AbcGeom::GeometryScope iScope,
+                                   std::vector < PlugAndObjScalar > & oScalars,
+                                   std::vector < PlugAndObjArray > & oArrays)
+{
+    std::string plugName = iPlug.partialName(0, 0, 0, 0, 0, 1).asChar();
+    switch (iType)
+    {
+        case MFnNumericData::kBoolean:
+        {
+            PlugAndObjScalar p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            Abc::OBoolProperty up(iParent, plugName, iTimeIndex);
+            p.prop = up;
+            oScalars.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::kByte:
+        case MFnNumericData::kChar:
+        {
+            PlugAndObjScalar p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            Abc::OCharProperty up(iParent, plugName, iTimeIndex);
+            p.prop = up;
+            oScalars.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::kShort:
+        {
+            PlugAndObjScalar p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            Abc::OInt16Property up(iParent, plugName, iTimeIndex);
+            p.prop = up;
+            oScalars.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::kInt:
+        {
+            PlugAndObjScalar p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            Abc::OInt32Property up(iParent, plugName, iTimeIndex);
+            p.prop = up;
+            oScalars.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::kFloat:
+        {
+            PlugAndObjScalar p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            Abc::OFloatProperty up(iParent, plugName, iTimeIndex);
+            p.prop = up;
+            oScalars.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::kDouble:
+        {
+            PlugAndObjScalar p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            Abc::ODoubleProperty up(iParent, plugName, iTimeIndex);
+            p.prop = up;
+            oScalars.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::k2Short:
+        {
+            PlugAndObjScalar p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            Abc::OV2sProperty up(iParent, plugName, iTimeIndex);
+            p.prop = up;
+            oScalars.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::k3Short:
+        {
+            PlugAndObjScalar p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            Abc::OV3sProperty up(iParent, plugName, iTimeIndex);
+            p.prop = up;
+            oScalars.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::k2Int:
+        {
+            PlugAndObjScalar p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            Abc::OV2iProperty up(iParent, plugName, iTimeIndex);
+            p.prop = up;
+            oScalars.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::k3Int:
+        {
+            PlugAndObjScalar p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            Abc::OV3iProperty up(iParent, plugName, iTimeIndex);
+            p.prop = up;
+            oScalars.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::k2Float:
+        {
+            PlugAndObjScalar p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            Abc::OV2fProperty up(iParent, plugName, iTimeIndex);
+            p.prop = up;
+            oScalars.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::k3Float:
+        {
+            PlugAndObjScalar p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            Abc::OV3fProperty up(iParent, plugName, iTimeIndex);
+            p.prop = up;
+            oScalars.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::k2Double:
+        {
+            PlugAndObjScalar p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            Abc::OV2dProperty up(iParent, plugName, iTimeIndex);
+            p.prop = up;
+            oScalars.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::k3Double:
+        {
+            PlugAndObjScalar p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            Abc::OV3dProperty up(iParent, plugName, iTimeIndex);
+            p.prop = up;
+            oScalars.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::k4Double:
+        {
+            PlugAndObjArray p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            AbcA::DataType dtype(Alembic::Util::kFloat64POD, 4);
+            Abc::OArrayProperty up(iParent, plugName, dtype, iTimeIndex);
+            p.prop = up;
+            oArrays.push_back(p);
+        }
+        break;
+
+        default:
+        break;
+    }
+}
+
+void createGeomPropertyFromNumeric(MFnNumericData::Type iType, const MObject& iAttr,
+                               const MPlug& iPlug, Abc::OCompoundProperty & iParent,
+                               Alembic::Util::uint32_t iTimeIndex,
+                               AbcGeom::GeometryScope iScope,
+                               std::vector < PlugAndObjArray > & oArrayVec)
+{
+    std::string plugName = iPlug.partialName(0, 0, 0, 0, 0, 1).asChar();
+    switch (iType)
+    {
+        case MFnNumericData::kBoolean:
+        {
+            PlugAndObjArray p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            AbcGeom::OBoolGeomParam gp(iParent, plugName, false, iScope, 1,
+                iTimeIndex);
+            p.prop = gp.getValueProperty();
+            oArrayVec.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::kByte:
+        case MFnNumericData::kChar:
+        {
+            PlugAndObjArray p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            AbcGeom::OCharGeomParam gp(iParent, plugName, false, iScope, 1,
+                iTimeIndex);
+            p.prop = gp.getValueProperty();
+            oArrayVec.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::kShort:
+        {
+            PlugAndObjArray p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            AbcGeom::OInt16GeomParam gp(iParent, plugName, false, iScope, 1,
+                iTimeIndex);
+            p.prop = gp.getValueProperty();
+            oArrayVec.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::kInt:
+        {
+            PlugAndObjArray p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            AbcGeom::OInt32GeomParam gp(iParent, plugName, false, iScope, 1,
+                iTimeIndex);
+            p.prop = gp.getValueProperty();
+            oArrayVec.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::kFloat:
+        {
+            PlugAndObjArray p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            AbcGeom::OFloatGeomParam gp(iParent, plugName, false, iScope, 1,
+                iTimeIndex);
+            p.prop = gp.getValueProperty();
+            oArrayVec.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::kDouble:
+        {
+            PlugAndObjArray p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            AbcGeom::ODoubleGeomParam gp(iParent, plugName, false, iScope, 1,
+                iTimeIndex);
+            p.prop = gp.getValueProperty();
+            oArrayVec.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::k2Short:
+        {
+            PlugAndObjArray p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            AbcGeom::OV2sGeomParam gp(iParent, plugName, false, iScope, 1,
+                iTimeIndex);
+            p.prop = gp.getValueProperty();
+            oArrayVec.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::k3Short:
+        {
+            PlugAndObjArray p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            AbcGeom::OV3sGeomParam gp(iParent, plugName, false, iScope, 1,
+                iTimeIndex);
+            p.prop = gp.getValueProperty();
+            oArrayVec.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::k2Int:
+        {
+            PlugAndObjArray p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            AbcGeom::OV2iGeomParam gp(iParent, plugName, false, iScope, 1,
+                iTimeIndex);
+            p.prop = gp.getValueProperty();
+            oArrayVec.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::k3Int:
+        {
+            PlugAndObjArray p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            AbcGeom::OV3iGeomParam gp(iParent, plugName, false, iScope, 1,
+                iTimeIndex);
+            p.prop = gp.getValueProperty();
+            oArrayVec.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::k2Float:
+        {
+            PlugAndObjArray p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            AbcGeom::OV2fGeomParam gp(iParent, plugName, false, iScope, 1,
+                iTimeIndex);
+            p.prop = gp.getValueProperty();
+            oArrayVec.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::k3Float:
+        {
+            PlugAndObjArray p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+
+            MFnAttribute mfnAttr(iAttr);
+            if (mfnAttr.isUsedAsColor())
+            {
+                AbcGeom::OC3fGeomParam gp(iParent, plugName, false, iScope, 1,
+                    iTimeIndex);
+                p.prop = gp.getValueProperty();
+            }
+            else
+            {
+                AbcGeom::OV3fGeomParam gp(iParent, plugName, false, iScope, 1,
+                    iTimeIndex);
+                p.prop = gp.getValueProperty();
+            }
+
+            oArrayVec.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::k2Double:
+        {
+            PlugAndObjArray p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            AbcGeom::OV2dGeomParam gp(iParent, plugName, false, iScope, 1,
+                iTimeIndex);
+            p.prop = gp.getValueProperty();
+            oArrayVec.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::k3Double:
+        {
+            PlugAndObjArray p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            AbcGeom::OV3dGeomParam gp(iParent, plugName, false, iScope, 1,
+                iTimeIndex);
+            p.prop = gp.getValueProperty();
+            oArrayVec.push_back(p);
+        }
+        break;
+
+        case MFnNumericData::k4Double:
+        {
+            PlugAndObjArray p;
+            p.plug = iPlug;
+            p.obj = iAttr;
+            AbcA::DataType dtype(Alembic::Util::kFloat64POD, 4);
+            p.prop = Abc::OArrayProperty(iParent, plugName, dtype, iTimeIndex);
+            oArrayVec.push_back(p);
+        }
+        break;
+
+        default:
+        break;
+    }
+}
+
+bool MFnNumericDataToSample(MFnNumericData::Type iType,
+                            const MPlug& iPlug,
+                            Abc::OScalarProperty & oProp)
+{
+    int    ival;
+    float  fval;
+    double dval;
+    bool   bval;
+    Alembic::Util::int16_t sval;
+    Alembic::Util::int8_t  cval;
+
+    Alembic::Util::int16_t v2sVal[2];
+    Alembic::Util::int16_t v3sVal[3];
+
+    Alembic::Util::int32_t v2iVal[2];
+    Alembic::Util::int32_t v3iVal[3];
+
+    float v2fVal[2];
+    float v3fVal[3];
+
+    double v2dVal[2];
+    double v3dVal[3];
+
+    switch (iType)
+    {
+        case MFnNumericData::kBoolean:
+        {
+            bval = iPlug.asBool();
+            oProp.set(&bval);
+        }
+        break;
+
+        case MFnNumericData::kByte:
+        case MFnNumericData::kChar:
+        {
+            cval = iPlug.asChar();
+            oProp.set(&cval);
+        }
+        break;
+
+        case MFnNumericData::kShort:
+        {
+            sval = iPlug.asShort();
+            oProp.set(&sval);
+        }
+        break;
+
+        case MFnNumericData::kInt:
+        {
+            ival = iPlug.asInt();
+            oProp.set(&ival);
+        }
+        break;
+
+        case MFnNumericData::kFloat:
+        {
+            fval = iPlug.asFloat();
+            oProp.set(&fval);
+        }
+        break;
+
+        case MFnNumericData::kDouble:
+        {
+            dval = iPlug.asDouble();
+            oProp.set(&dval);
+        }
+        break;
+
+        case MFnNumericData::k2Short:
+        {
+            MFnNumericData numdFn(iPlug.asMObject());
+            numdFn.getData2Short(v2sVal[0], v2sVal[1]);
+
+            oProp.set(&v2sVal[0]);
+        }
+        break;
+
+        case MFnNumericData::k3Short:
+        {
+            MFnNumericData numdFn(iPlug.asMObject());
+            numdFn.getData3Short(v3sVal[0], v3sVal[1], v3sVal[2]);
+
+            oProp.set(&v3sVal[0]);
+        }
+        break;
+
+        case MFnNumericData::k2Int:
+        {
+            int val0, val1;
+            MFnNumericData numdFn(iPlug.asMObject());
+            numdFn.getData2Int(val0, val1);
+            v2iVal[0] = Alembic::Util::int32_t(val0);
+            v2iVal[1] = Alembic::Util::int32_t(val1);
+
+            oProp.set(&v2iVal[0]);
+        }
+        break;
+
+        case MFnNumericData::k3Int:
+        {
+            int val0, val1, val2;
+            MFnNumericData numdFn(iPlug.asMObject());
+            numdFn.getData3Int(val0, val1, val2);
+            v3iVal[0] = Alembic::Util::int32_t(val0);
+            v3iVal[1] = Alembic::Util::int32_t(val1);
+            v3iVal[2] = Alembic::Util::int32_t(val2);
+
+            oProp.set(&v3iVal[0]);
+        }
+        break;
+
+        case MFnNumericData::k2Float:
+        {
+            MFnNumericData numdFn(iPlug.asMObject());
+            numdFn.getData2Float(v2fVal[0], v2fVal[1]);
+
+            oProp.set(&v2fVal[0]);
+        }
+        break;
+
+        case MFnNumericData::k3Float:
+        {
+            MFnNumericData numdFn(iPlug.asMObject());
+            numdFn.getData3Float(v3fVal[0], v3fVal[1], v3fVal[2]);
+
+            oProp.set(&v3fVal[0]);
+        }
+        break;
+
+        case MFnNumericData::k2Double:
+        {
+            MFnNumericData numdFn(iPlug.asMObject());
+            numdFn.getData2Double(v2dVal[0], v3dVal[1]);
+
+            oProp.set(&v2dVal[0]);
+        }
+        break;
+
+        case MFnNumericData::k3Double:
+        {
+            MFnNumericData numdFn(iPlug.asMObject());
+            numdFn.getData3Double(v3dVal[0], v3dVal[1], v3dVal[2]);
+
+            oProp.set(&v3dVal[0]);
+        }
+        break;
+
+        default:
+            return false;
+        break;
+    }
+
+    return true;
+}
+
+bool MFnNumericDataToSample(MFnNumericData::Type iType,
+                            const MPlug& iPlug,
+                            Abc::OArrayProperty & oProp)
+{
+    unsigned int numElements =  iPlug.numElements();
+    bool isArray = iPlug.isArray();
+
+    unsigned int dimSize = numElements;
+    if (!isArray)
+        dimSize = 1;
+
+    switch (iType)
+    {
+        case MFnNumericData::kBoolean:
+        {
+            std::vector< Alembic::Util::bool_t > val(dimSize);
+            if (!isArray)
+            {
+                val[0] = iPlug.asBool();
+            }
+            else
+            {
+                for (unsigned int i = 0; i < numElements; ++i)
+                {
+                    val[i] = iPlug[i].asBool();
+                }
+            }
+            AbcA::ArraySample samp(&(val.front()), oProp.getDataType(),
+                Alembic::Util::Dimensions(dimSize));
+            oProp.set(samp);
+        }
+        break;
+
+        case MFnNumericData::kByte:
+        case MFnNumericData::kChar:
+        {
+            std::vector< Alembic::Util::int8_t > val(dimSize);
+            if (!isArray)
+            {
+                val[0] = iPlug.asChar();
+            }
+            else
+            {
+                for (unsigned int i = 0; i < numElements; ++i)
+                {
+                    val[i] = iPlug[i].asChar();
+                }
+            }
+            AbcA::ArraySample samp(&(val.front()), oProp.getDataType(),
+                Alembic::Util::Dimensions(dimSize));
+            oProp.set(samp);
+        }
+        break;
+
+        case MFnNumericData::kShort:
+        {
+            std::vector< Alembic::Util::int16_t > val(dimSize);
+            if (!isArray)
+            {
+                val[0] = iPlug.asShort();
+            }
+            else
+            {
+                for (unsigned int i = 0; i < numElements; ++i)
+                {
+                    val[i] = iPlug[i].asShort();
+                }
+            }
+            AbcA::ArraySample samp(&(val.front()), oProp.getDataType(),
+                Alembic::Util::Dimensions(dimSize));
+            oProp.set(samp);
+        }
+        break;
+
+        case MFnNumericData::kInt:
+        {
+            std::vector< Alembic::Util::int32_t > val(dimSize);
+            if (!isArray)
+            {
+                val[0] = iPlug.asInt();
+            }
+            else
+            {
+                for (unsigned int i = 0; i < numElements; ++i)
+                {
+                    val[i] = iPlug[i].asInt();
+                }
+            }
+            AbcA::ArraySample samp(&(val.front()), oProp.getDataType(),
+                Alembic::Util::Dimensions(dimSize));
+            oProp.set(samp);
+        }
+        break;
+
+        case MFnNumericData::kFloat:
+        {
+            std::vector<float> val(dimSize);
+            if (!isArray)
+            {
+                val[0] = iPlug.asFloat();
+            }
+            else
+            {
+                for (unsigned int i = 0; i < numElements; ++i)
+                {
+                    val[i] = iPlug[i].asFloat();
+                }
+            }
+            AbcA::ArraySample samp(&(val.front()), oProp.getDataType(),
+                Alembic::Util::Dimensions(dimSize));
+            oProp.set(samp);
+        }
+        break;
+
+        case MFnNumericData::kDouble:
+        {
+            std::vector<double> val(dimSize);
+            if (!isArray)
+            {
+                val[0] = iPlug.asDouble();
+            }
+            else
+            {
+                for (unsigned int i = 0; i < numElements; ++i)
+                {
+                    val[i] = iPlug[i].asDouble();
+                }
+            }
+            AbcA::ArraySample samp(&(val.front()), oProp.getDataType(),
+                Alembic::Util::Dimensions(dimSize));
+            oProp.set(samp);
+        }
+        break;
+
+        case MFnNumericData::k2Short:
+        {
+            std::vector< Alembic::Util::int16_t > val(dimSize*2);
+            if (!isArray)
+            {
+                MFnNumericData numdFn(iPlug.asMObject());
+                numdFn.getData2Short(val[0], val[1]);
+            }
+            else
+            {
+                for (unsigned int i = 0; i < numElements; ++i)
+                {
+                    MFnNumericData numdFn(iPlug[i].asMObject());
+                    numdFn.getData2Short(val[2*i], val[2*i+1]);
+                }
+            }
+            AbcA::ArraySample samp(&(val.front()), oProp.getDataType(),
+                Alembic::Util::Dimensions(dimSize));
+            oProp.set(samp);
+        }
+        break;
+
+        case MFnNumericData::k3Short:
+        {
+            std::vector< Alembic::Util::int16_t > val(dimSize*3);
+            if (!isArray)
+            {
+                MFnNumericData numdFn(iPlug.asMObject());
+                numdFn.getData3Short(val[0], val[1], val[2]);
+            }
+            else
+            {
+                for (unsigned int i = 0; i < numElements; ++i)
+                {
+                    MFnNumericData numdFn(iPlug[i].asMObject());
+                    numdFn.getData3Short(val[3*i], val[3*i+1], val[3*i+2]);
+                }
+            }
+            AbcA::ArraySample samp(&(val.front()), oProp.getDataType(),
+                Alembic::Util::Dimensions(dimSize));
+            oProp.set(samp);
+        }
+        break;
+
+        case MFnNumericData::k2Int:
+        {
+            std::vector< Alembic::Util::int32_t > val(dimSize*2);
+            if (!isArray)
+            {
+                int val0, val1;
+                MFnNumericData numdFn(iPlug.asMObject());
+                numdFn.getData2Int(val0, val1);
+                val[0] = Alembic::Util::int32_t(val0);
+                val[1] = Alembic::Util::int32_t(val1);
+            }
+            else
+            {
+                for (unsigned int i = 0; i < numElements; ++i)
+                {
+                    int val0, val1;
+                    MFnNumericData numdFn(iPlug[i].asMObject());
+                    numdFn.getData2Int(val0, val1);
+                    val[2*i] = Alembic::Util::int32_t(val0);
+                    val[2*i+1] = Alembic::Util::int32_t(val1);
+                }
+            }
+            AbcA::ArraySample samp(&(val.front()), oProp.getDataType(),
+                Alembic::Util::Dimensions(dimSize));
+            oProp.set(samp);
+        }
+        break;
+
+        case MFnNumericData::k3Int:
+        {
+            std::vector< Alembic::Util::int32_t > val(dimSize*3);
+            if (!isArray)
+            {
+                int val0, val1, val2;
+                MFnNumericData numdFn(iPlug.asMObject());
+                numdFn.getData3Int(val0, val1, val2);
+                val[0] = Alembic::Util::int32_t(val0);
+                val[1] = Alembic::Util::int32_t(val1);
+                val[2] = Alembic::Util::int32_t(val2);
+            }
+            else
+            {
+                for (unsigned int i = 0; i < numElements; ++i)
+                {
+                    int val0, val1, val2;
+                    MFnNumericData numdFn(iPlug[i].asMObject());
+                    numdFn.getData3Int(val0, val1, val2);
+                    val[3*i] = Alembic::Util::int32_t(val0);
+                    val[3*i+1] = Alembic::Util::int32_t(val1);
+                    val[3*i+2] = Alembic::Util::int32_t(val2);
+                }
+            }
+            AbcA::ArraySample samp(&(val.front()), oProp.getDataType(),
+                Alembic::Util::Dimensions(dimSize));
+            oProp.set(samp);
+        }
+        break;
+
+        case MFnNumericData::k2Float:
+        {
+            std::vector<float> val(dimSize*2);
+            if (!isArray)
+            {
+                MFnNumericData numdFn(iPlug.asMObject());
+                numdFn.getData2Float(val[0], val[1]);
+            }
+            else
+            {
+                for (unsigned int i = 0; i < numElements; ++i)
+                {
+                    MFnNumericData numdFn(iPlug[i].asMObject());
+                    numdFn.getData2Float(val[2*i], val[2*i+1]);
+                }
+            }
+            AbcA::ArraySample samp(&(val.front()), oProp.getDataType(),
+                Alembic::Util::Dimensions(dimSize));
+            oProp.set(samp);
+        }
+        break;
+
+        case MFnNumericData::k3Float:
+        {
+            std::vector<float> val(dimSize*3);
+            if (!isArray)
+            {
+                MFnNumericData numdFn(iPlug.asMObject());
+                numdFn.getData3Float(val[0], val[1], val[2]);
+            }
+            else
+            {
+                for (unsigned int i = 0; i < numElements; ++i)
+                {
+                    MFnNumericData numdFn(iPlug[i].asMObject());
+                    numdFn.getData3Float(val[3*i], val[3*i+1], val[3*i+2]);
+                }
+            }
+            AbcA::ArraySample samp(&(val.front()), oProp.getDataType(),
+                Alembic::Util::Dimensions(dimSize));
+            oProp.set(samp);
+        }
+        break;
+
+        case MFnNumericData::k2Double:
+        {
+            std::vector<double> val(dimSize*2);
+            if (!isArray)
+            {
+                MFnNumericData numdFn(iPlug.asMObject());
+                numdFn.getData2Double(val[0], val[1]);
+            }
+            else
+            {
+                for (unsigned int i = 0; i < numElements; ++i)
+                {
+                    MFnNumericData numdFn(iPlug[i].asMObject());
+                    numdFn.getData2Double(val[2*i], val[2*i+1]);
+                }
+            }
+            AbcA::ArraySample samp(&(val.front()), oProp.getDataType(),
+                Alembic::Util::Dimensions(dimSize));
+            oProp.set(samp);
+        }
+        break;
+
+        case MFnNumericData::k3Double:
+        {
+            std::vector<double> val(dimSize*3);
+            if (!isArray)
+            {
+                MFnNumericData numdFn(iPlug.asMObject());
+                numdFn.getData3Double(val[0], val[1], val[2]);
+            }
+            else
+            {
+                for (unsigned int i = 0; i < numElements; ++i)
+                {
+                    MFnNumericData numdFn(iPlug[i].asMObject());
+                    numdFn.getData3Double(val[3*i], val[3*i+1], val[3*i+2]);
+                }
+            }
+            AbcA::ArraySample samp(&(val.front()), oProp.getDataType(),
+                Alembic::Util::Dimensions(dimSize));
+            oProp.set(samp);
+        }
+        break;
+
+        case MFnNumericData::k4Double:
+        {
+            std::vector<double> val(dimSize*4);
+            if (!isArray)
+            {
+                MFnNumericData numdFn(iPlug.asMObject());
+                numdFn.getData4Double(val[0], val[1], val[2], val[3]);
+            }
+            else
+            {
+                for (unsigned int i = 0; i < numElements; ++i)
+                {
+                    MFnNumericData numdFn(iPlug[i].asMObject());
+                    numdFn.getData4Double(val[4*i], val[4*i+1], val[4*i+2],
+                        val[4*i+3]);
+                }
+            }
+            AbcA::ArraySample samp(&(val.front()), oProp.getDataType(),
+                Alembic::Util::Dimensions(dimSize));
+            oProp.set(samp);
+        }
+        break;
+
+        default:
+            return false;
+        break;
+    }
+
+    return true;
+}
+
+bool MFnTypedDataToSample(MFnData::Type iType,
+                          const MPlug& iPlug,
+                          Abc::OScalarProperty & oProp)
+{
+    size_t numElements =  iPlug.numElements();
+    bool isArray = iPlug.isArray();
+
+    size_t dimSize = numElements;
+    if (!isArray)
+        dimSize = 1;
+
+    switch (iType)
+    {
+        case MFnData::kNumeric:
+        {
+            MFnNumericData numObj(iPlug.asMObject());
+            return MFnNumericDataToSample(numObj.numericType(), iPlug,
+                oProp);
+        }
+        break;
+
+        case MFnData::kString:
+        {
+            Abc::OStringProperty strProp( oProp.getPtr(), Abc::kWrapExisting );
+            std::string val = iPlug.asString().asChar();
+            strProp.set(val);
+        }
+        break;
+
+        case MFnData::kMatrix:
+        {
+            MFnMatrixData arr(iPlug.asMObject());
+            MMatrix mat = arr.matrix();
+            double val[16];
+
+            unsigned int i = 0;
+            for (unsigned int r = 0; r < 4; r++)
+            {
+                for (unsigned int c = 0; c < 4; c++, i++)
+                {
+                    val[i] = mat[r][c];
+                }
+            }
+
+            oProp.set(&val);
+        }
+        break;
+
+        default:
+            return false;
+        break;
+    }
+
+    return true;
+}
+
+bool MFnTypedDataToSample(MFnData::Type iType,
+                          const MPlug& iPlug,
+                          Abc::OArrayProperty & oProp)
+{
+    size_t numElements =  iPlug.numElements();
+    bool isArray = iPlug.isArray();
+
+    size_t dimSize = numElements;
+    if (!isArray)
+        dimSize = 1;
+
+    switch (iType)
+    {
+        case MFnData::kNumeric:
+        {
+            MFnNumericData numObj(iPlug.asMObject());
+            return MFnNumericDataToSample(numObj.numericType(), iPlug,
+                oProp);
+        }
+        break;
+
+        case MFnData::kString:
+        {
+            std::vector< std::string > val(1);
+            val[0] = iPlug.asString().asChar();
+            AbcA::ArraySample samp(&(val.front()), oProp.getDataType(),
+                Alembic::Util::Dimensions(1));
+            oProp.set(samp);
+        }
+        break;
+
+        case MFnData::kStringArray:
+        {
+            MFnStringArrayData arr(iPlug.asMObject());
+
+            unsigned int length = arr.length();
+            std::vector< std::string > val(length);
+            for (unsigned int i = 0; i < length; i++)
+            {
+                val[i] = arr[i].asChar();
+            }
+            AbcA::ArraySample samp(&(val.front()), oProp.getDataType(),
+                Alembic::Util::Dimensions(length));
+            oProp.set(samp);
+        }
+        break;
+
+        case MFnData::kDoubleArray:
+        {
+            MFnDoubleArrayData arr(iPlug.asMObject());
+
+            unsigned int length = arr.length();
+            std::vector< double > val(length);
+            for (unsigned int i = 0; i < length; i++)
+            {
+                val[i] = arr[i];
+            }
+            AbcA::ArraySample samp(&(val.front()), oProp.getDataType(),
+                Alembic::Util::Dimensions(length));
+            oProp.set(samp);
+        }
+        break;
+
+        case MFnData::kFloatArray:
+        {
+            MFnFloatArrayData arr(iPlug.asMObject());
+
+            unsigned int length = arr.length();
+            std::vector< float > val(length);
+            for (unsigned int i = 0; i < length; i++)
+            {
+                val[i] = arr[i];
+            }
+            AbcA::ArraySample samp(&(val.front()), oProp.getDataType(),
+                Alembic::Util::Dimensions(length));
+            oProp.set(samp);
+        }
+        break;
+
+        case MFnData::kIntArray:
+        {
+            MFnIntArrayData arr(iPlug.asMObject());
+
+            unsigned int length = arr.length();
+            std::vector< Alembic::Util::int32_t > val(length);
+            for (unsigned int i = 0; i < length; i++)
+            {
+                val[i] = arr[i];
+            }
+            AbcA::ArraySample samp(&(val.front()), oProp.getDataType(),
+                Alembic::Util::Dimensions(length));
+            oProp.set(samp);
+        }
+        break;
+
+        case MFnData::kPointArray:
+        {
+            MFnPointArrayData arr(iPlug.asMObject());
+
+            unsigned int length = arr.length();
+            unsigned int extent = oProp.getDataType().getExtent();
+            std::vector< double > val(length*extent);
+            for (unsigned int i = 0; i < length; i++)
+            {
+                MPoint pt(arr[i]);
+                val[extent*i] = pt.x;
+                val[extent*i+1] = pt.y;
+
+                if (extent > 2)
+                    val[extent*i+2] = pt.z;
+
+                if (extent > 3)
+                    val[extent*i+3] = pt.w;
+            }
+            AbcA::ArraySample samp(&(val.front()), oProp.getDataType(),
+                Alembic::Util::Dimensions(length));
+            oProp.set(samp);
+        }
+        break;
+
+        case MFnData::kVectorArray:
+        {
+            MFnVectorArrayData arr(iPlug.asMObject());
+
+            unsigned int length = arr.length();
+            unsigned int extent = oProp.getDataType().getExtent();
+            std::vector< double > val(length*extent);
+            for (unsigned int i = 0; i < length; i++)
+            {
+                MVector v(arr[i]);
+                val[extent*i] = v.x;
+                val[extent*i+1] = v.y;
+
+                if (extent > 2)
+                   val[extent*i+2] = v.z;
+            }
+            AbcA::ArraySample samp(&(val.front()), oProp.getDataType(),
+                Alembic::Util::Dimensions(length));
+            oProp.set(samp);
+        }
+        break;
+
+        case MFnData::kMatrix:
+        {
+            MFnMatrixData arr(iPlug.asMObject());
+            MMatrix mat = arr.matrix();
+            std::vector<double> val(16);
+
+            unsigned int i = 0;
+            for (unsigned int r = 0; r < 4; r++)
+            {
+                for (unsigned int c = 0; c < 4; c++, i++)
+                {
+                    val[i] = mat[r][c];
+                }
+            }
+            AbcA::ArraySample samp(&(val.front()), oProp.getDataType(),
+                Alembic::Util::Dimensions(1));
+            oProp.set(samp);
+        }
+        break;
+
+        default:
+            return false;
+        break;
+    }
+
+    return true;
+}
+
+bool attributeToScalarPropertyPair(const MObject& iAttr,
+                                   const MPlug& iPlug,
+                                   Abc::OScalarProperty & oProp)
+{
+    if (iAttr.hasFn(MFn::kTypedAttribute))
+    {
+        MFnTypedAttribute typedAttr(iAttr);
+        return MFnTypedDataToSample(typedAttr.attrType(), iPlug, oProp);
+    }
+    else if (iAttr.hasFn(MFn::kNumericAttribute))
+    {
+        MFnNumericAttribute numAttr(iAttr);
+        return MFnNumericDataToSample(numAttr.unitType(), iPlug, oProp);
+    }
+    else if (iAttr.hasFn(MFn::kUnitAttribute))
+    {
+        double dval = iPlug.asDouble();
+        oProp.set(&dval);
+        return true;
+    }
+    else if (iAttr.hasFn(MFn::kEnumAttribute))
+    {
+        Alembic::Util::int16_t val = iPlug.asShort();
+        oProp.set(&val);
+        return true;
+    }
+
+    return false;
+}
+
+
+bool attributeToArrayPropertyPair(const MObject& iAttr,
+                                  const MPlug& iPlug,
+                                  Abc::OArrayProperty & oProp)
+{
+    if (iAttr.hasFn(MFn::kTypedAttribute))
+    {
+        MFnTypedAttribute typedAttr(iAttr);
+        return MFnTypedDataToSample(typedAttr.attrType(), iPlug,
+            oProp);
+    }
+    else if (iAttr.hasFn(MFn::kNumericAttribute))
+    {
+        MFnNumericAttribute numAttr(iAttr);
+        return MFnNumericDataToSample(numAttr.unitType(), iPlug,
+            oProp);
+    }
+    else if (iAttr.hasFn(MFn::kUnitAttribute))
+    {
+        double val = iPlug.asDouble();
+        AbcA::ArraySample samp(&val, oProp.getDataType(),
+            Alembic::Util::Dimensions(1));
+        oProp.set(samp);
+        return true;
+    }
+    else if (iAttr.hasFn(MFn::kEnumAttribute))
+    {
+        Alembic::Util::int16_t val = iPlug.asShort();
+        AbcA::ArraySample samp(&val, oProp.getDataType(),
+            Alembic::Util::Dimensions(1));
+        oProp.set(samp);
+        return true;
+    }
+
+    return false;
+}
+
+void createUserPropertyFromMFnAttr(const MObject& iAttr,
+                                   const MPlug& iPlug,
+                                   Abc::OCompoundProperty & iParent,
+                                   Alembic::Util::uint32_t iTimeIndex,
+                                   AbcGeom::GeometryScope iScope,
+                                   const MString & iTypeStr,
+                                   std::vector < PlugAndObjScalar > & oScalars,
+                                   std::vector < PlugAndObjArray > & oArrays)
+{
+    MStatus stat;
+    std::string plugName = iPlug.partialName(0, 0, 0, 0, 0, 1).asChar();
+
+    if (iAttr.hasFn(MFn::kNumericAttribute))
+    {
+        MFnNumericAttribute numFn(iAttr, &stat);
+
+        if (!stat)
+        {
+            MString err = "Couldn't instantiate MFnNumericAttribute\n\tType: ";
+            err += iAttr.apiTypeStr();
+            MGlobal::displayError(err);
+
+            return;
+        }
+
+        createUserPropertyFromNumeric(numFn.unitType(), iAttr, iPlug,
+                                      iParent, iTimeIndex, iScope,
+                                      oScalars, oArrays);
+    }
+    else if (iAttr.hasFn(MFn::kTypedAttribute))
+    {
+        MFnTypedAttribute typeFn(iAttr, &stat);
+
+        if (!stat)
+        {
+            MString err = "Couldn't instantiate MFnTypedAttribute\n\tType: ";
+            err += iAttr.apiTypeStr();
+
+            MGlobal::displayError(err);
+
+            return;
+        }
+
+        switch (typeFn.attrType())
+        {
+            case MFnData::kString:
+            {
+                PlugAndObjScalar p;
+                p.plug = iPlug;
+                p.obj = iAttr;
+                p.prop = Abc::OStringProperty(iParent, plugName, iTimeIndex);
+                oScalars.push_back(p);
+            }
+            break;
+
+            case MFnData::kStringArray:
+            {
+                PlugAndObjArray p;
+                p.plug = iPlug;
+                p.obj = iAttr;
+                p.prop = Abc::OStringArrayProperty(iParent, plugName, iTimeIndex);
+                oArrays.push_back(p);
+            }
+            break;
+
+            case MFnData::kDoubleArray:
+            {
+                PlugAndObjArray p;
+                p.plug = iPlug;
+                p.obj = iAttr;
+                p.prop = Abc::ODoubleArrayProperty(iParent, plugName, iTimeIndex);
+                oArrays.push_back(p);
+            }
+            break;
+
+            case MFnData::kFloatArray:
+            {
+                PlugAndObjArray p;
+                p.plug = iPlug;
+                p.obj = iAttr;
+                p.prop = Abc::OFloatArrayProperty(iParent, plugName, iTimeIndex);
+                oArrays.push_back(p);
+            }
+            break;
+
+            case MFnData::kIntArray:
+            {
+                PlugAndObjArray p;
+                p.plug = iPlug;
+                p.obj = iAttr;
+                p.prop = Abc::OInt32ArrayProperty(iParent, plugName, iTimeIndex);
+                oArrays.push_back(p);
+            }
+            break;
+
+            case MFnData::kPointArray:
+            {
+                PlugAndObjArray p;
+                p.plug = iPlug;
+                p.obj = iAttr;
+                if (iTypeStr  == "point2")
+                    p.prop = Abc::OP2dArrayProperty(iParent, plugName, iTimeIndex);
+                else
+                    p.prop = Abc::OP3dArrayProperty(iParent, plugName, iTimeIndex);
+
+                oArrays.push_back(p);
+            }
+            break;
+
+            case MFnData::kVectorArray:
+            {
+                PlugAndObjArray p;
+                p.plug = iPlug;
+                p.obj = iAttr;
+                if (iTypeStr == "vector2")
+                    p.prop = Abc::OV2dArrayProperty(iParent, plugName, iTimeIndex);
+                else if (iTypeStr == "normal2")
+                    p.prop = Abc::ON2dArrayProperty(iParent, plugName, iTimeIndex);
+                else if (iTypeStr == "normal3")
+                    p.prop = Abc::ON3dArrayProperty(iParent, plugName, iTimeIndex);
+                else
+                    p.prop = Abc::OV3dArrayProperty(iParent, plugName, iTimeIndex);
+
+                oArrays.push_back(p);
+            }
+            break;
+
+            case MFnData::kMatrix:
+            {
+                PlugAndObjScalar p;
+                p.plug = iPlug;
+                p.obj = iAttr;
+                p.prop = Abc::OM44dProperty(iParent, plugName, iTimeIndex);
+                oScalars.push_back(p);
+            }
+            break;
+
+            case MFnData::kNumeric:
+            {
+                MFnNumericAttribute numAttr(iPlug.asMObject());
+                createUserPropertyFromNumeric(numAttr.unitType(), iAttr,
+                    iPlug, iParent, iTimeIndex, iScope, oScalars, oArrays);
+            }
+            break;
+
+            default:
+            {
+                // get the full property name for the warning
+                MString msg = "WARNING: Couldn't convert ";
+                msg += iPlug.partialName(1, 0, 0, 0, 1, 1);
+                msg += " to a property, so skipping.";
+                MGlobal::displayWarning(msg);
+            }
+            break;
+        }
+    }
+    else if (iAttr.hasFn(MFn::kUnitAttribute))
+    {
+        PlugAndObjScalar p;
+        p.plug = iPlug;
+        p.obj = iAttr;
+        p.prop = Abc::ODoubleProperty(iParent, plugName, iTimeIndex);
+        oScalars.push_back(p);
+    }
+    else if (iAttr.hasFn(MFn::kEnumAttribute))
+    {
+        PlugAndObjScalar p;
+        p.plug = iPlug;
+        p.obj = iAttr;
+        p.prop = Abc::OInt16Property(iParent, plugName, iTimeIndex);
+        oScalars.push_back(p);
+    }
+}
+
+void createGeomPropertyFromMFnAttr(const MObject& iAttr,
+                                   const MPlug& iPlug,
+                                   Abc::OCompoundProperty & iParent,
+                                   Alembic::Util::uint32_t iTimeIndex,
+                                   AbcGeom::GeometryScope iScope,
+                                   const MString & iTypeStr,
+                                   std::vector < PlugAndObjArray > & oArrayVec)
+{
+    // for some reason we have just 1 of the elements of an array, bail
+    if (iPlug.isElement())
+        return;
+
+    MStatus stat;
+
+    std::string plugName = iPlug.partialName(0, 0, 0, 0, 0, 1).asChar();
+
+    if (iAttr.hasFn(MFn::kNumericAttribute))
+    {
+        MFnNumericAttribute numFn(iAttr, &stat);
+
+        if (!stat)
+        {
+            MString err = "Couldn't instantiate MFnNumericAttribute\n\tType: ";
+            err += iAttr.apiTypeStr();
+            MGlobal::displayError(err);
+
+            return;
+        }
+
+        createGeomPropertyFromNumeric(numFn.unitType(), iAttr, iPlug, iParent,
+            iTimeIndex, iScope, oArrayVec);
+    }
+    else if (iAttr.hasFn(MFn::kTypedAttribute))
+    {
+        MFnTypedAttribute typeFn(iAttr, &stat);
+        if (!stat)
+        {
+            MString err = "Couldn't instantiate MFnTypedAttribute\n\tType: ";
+            err += iAttr.apiTypeStr();
+
+            MGlobal::displayError(err);
+
+            return;
+        }
+
+        Alembic::AbcCoreAbstract::MetaData md;
+        md.set("isArray", "1");
+
+        switch (typeFn.attrType())
+        {
+            case MFnData::kString:
+            {
+                PlugAndObjArray p;
+                p.plug = iPlug;
+                p.obj = iAttr;
+                AbcGeom::OStringGeomParam gp(iParent, plugName, false, iScope,
+                    1, iTimeIndex);
+                p.prop = gp.getValueProperty();
+                oArrayVec.push_back(p);
+            }
+            break;
+
+            case MFnData::kStringArray:
+            {
+                PlugAndObjArray p;
+                p.plug = iPlug;
+                p.obj = iAttr;
+                AbcGeom::OStringGeomParam gp(iParent, plugName, false, iScope,
+                    1, iTimeIndex, md);
+                p.prop = gp.getValueProperty();
+                oArrayVec.push_back(p);
+            }
+            break;
+
+            case MFnData::kDoubleArray:
+            {
+                PlugAndObjArray p;
+                p.plug = iPlug;
+                p.obj = iAttr;
+                AbcGeom::ODoubleGeomParam gp(iParent, plugName, false, iScope,
+                    1, iTimeIndex, md);
+                p.prop = gp.getValueProperty();
+                oArrayVec.push_back(p);
+            }
+            break;
+
+            case MFnData::kFloatArray:
+            {
+                PlugAndObjArray p;
+                p.plug = iPlug;
+                p.obj = iAttr;
+                AbcGeom::OFloatGeomParam gp(iParent, plugName, false, iScope,
+                    1, iTimeIndex, md);
+                p.prop = gp.getValueProperty();
+                oArrayVec.push_back(p);
+            }
+            break;
+
+            case MFnData::kIntArray:
+            {
+                PlugAndObjArray p;
+                p.plug = iPlug;
+                p.obj = iAttr;
+                AbcGeom::OInt32GeomParam gp(iParent, plugName, false, iScope,
+                    1, iTimeIndex, md);
+                p.prop = gp.getValueProperty();
+                oArrayVec.push_back(p);
+            }
+            break;
+
+            case MFnData::kPointArray:
+            {
+                PlugAndObjArray p;
+                p.plug = iPlug;
+                p.obj = iAttr;
+                if (iTypeStr  == "point2")
+                {
+                    AbcGeom::OP2dGeomParam gp(iParent, plugName, false, iScope,
+                        1, iTimeIndex, md);
+                    p.prop = gp.getValueProperty();
+                }
+                else
+                {
+                    AbcGeom::OP3dGeomParam gp(iParent, plugName, false, iScope,
+                        1, iTimeIndex);
+                    p.prop = gp.getValueProperty();
+                }
+                oArrayVec.push_back(p);
+            }
+            break;
+
+            case MFnData::kVectorArray:
+            {
+                PlugAndObjArray p;
+                p.plug = iPlug;
+                p.obj = iAttr;
+                if (iTypeStr == "vector2")
+                {
+                    AbcGeom::OV2dGeomParam gp(iParent, plugName, false, iScope,
+                        1, iTimeIndex, md);
+                    p.prop = gp.getValueProperty();
+                }
+                else if (iTypeStr == "normal2")
+                {
+                    AbcGeom::ON2dGeomParam gp(iParent, plugName, false, iScope,
+                        1, iTimeIndex, md);
+                    p.prop = gp.getValueProperty();
+                }
+                else if (iTypeStr == "normal3")
+                {
+                    AbcGeom::ON3dGeomParam gp(iParent, plugName, false, iScope,
+                        1, iTimeIndex, md);
+                    p.prop = gp.getValueProperty();
+                }
+                else
+                {
+                    AbcGeom::OV3dGeomParam gp(iParent, plugName, false, iScope,
+                        1, iTimeIndex, md);
+                    p.prop = gp.getValueProperty();
+                }
+                oArrayVec.push_back(p);
+            }
+            break;
+
+            case MFnData::kMatrix:
+            {
+                PlugAndObjArray p;
+                p.plug = iPlug;
+                p.obj = iAttr;
+                AbcGeom::OM44dGeomParam gp(iParent, plugName, false, iScope, 1,
+                    iTimeIndex);
+                p.prop = gp.getValueProperty();
+                oArrayVec.push_back(p);
+            }
+            break;
+
+            case MFnData::kNumeric:
+            {
+                MFnNumericAttribute numAttr(iPlug.asMObject());
+                createGeomPropertyFromNumeric(numAttr.unitType(), iAttr,
+                    iPlug, iParent, iTimeIndex, iScope, oArrayVec);
+            }
+            break;
+
+            default:
+            {
+                // get the full property name for the warning
+                MString msg = "WARNING: Couldn't convert ";
+                msg += iPlug.partialName(1, 0, 0, 0, 1, 1);
+                msg += " to a property, so skipping.";
+                MGlobal::displayWarning(msg);
+            }
+            break;
+        }
+    }
+    else if (iAttr.hasFn(MFn::kUnitAttribute))
+    {
+        PlugAndObjArray p;
+        p.plug = iPlug;
+        p.obj = iAttr;
+        AbcGeom::ODoubleGeomParam gp(iParent, plugName, false, iScope, 1,
+            iTimeIndex);
+        p.prop = gp.getValueProperty();
+        oArrayVec.push_back(p);
+    }
+    else if (iAttr.hasFn(MFn::kEnumAttribute))
+    {
+        PlugAndObjArray p;
+        p.plug = iPlug;
+        p.obj = iAttr;
+        AbcGeom::OInt16GeomParam gp(iParent, plugName, false, iScope, 1,
+            iTimeIndex);
+        p.prop = gp.getValueProperty();
+        oArrayVec.push_back(p);
+    }
+}
+
+}
+
+AttributesWriter::AttributesWriter(
+    Alembic::Abc::OCompoundProperty & iArbGeom,
+    Alembic::Abc::OCompoundProperty & iUserProps,
+    Alembic::Abc::OObject & iParentObj,
+    const MFnDependencyNode & iNode,
+    Alembic::Util::uint32_t iTimeIndex,
+    const AlembicWriteJob & iWriteJob)
+{
+    unsigned int attrCount = iNode.attributeCount();
+    unsigned int i;
+
+    std::vector< PlugAndObjArray > staticPlugObjArrayVec;
+    std::vector< PlugAndObjScalar > staticPlugObjScalarVec;
+
+    for (i = 0; i < attrCount; i++)
+    {
+        MObject attr = iNode.attribute(i);
+        MFnAttribute mfnAttr(attr);
+        MPlug plug = iNode.findPlug(attr, true);
+
+        // if it is not readable, then bail without any more checking
+        if (!mfnAttr.isReadable() || plug.isNull())
+            continue;
+
+        MString propName = plug.partialName(0, 0, 0, 0, 0, 1);
+
+        std::string propStr = propName.asChar();
+
+        // we handle visibility elsewhere
+        if (propStr == "visibility")
+        {
+            continue;
+        }
+
+        bool userAttr = false;
+        if (!matchFilterOrAttribs(plug, iWriteJob, userAttr))
+            continue;
+
+        if (userAttr && !iUserProps.valid())
+            continue;
+        if (!userAttr && !iArbGeom.valid())
+            continue;
+
+        int sampType = util::getSampledType(plug);
+
+        MPlug scopePlug = iNode.findPlug(propName + cAttrScope);
+        AbcGeom::GeometryScope scope = AbcGeom::kUnknownScope;
+
+        if (!scopePlug.isNull())
+        {
+            scope = strToScope(scopePlug.asString());
+        }
+
+        MString typeStr;
+        MPlug typePlug = iNode.findPlug(propName + cAttrType);
+        if (!typePlug.isNull())
+        {
+            typeStr= typePlug.asString();
+        }
+
+        if (userAttr)
+        {
+            switch (sampType)
+            {
+                // static
+                case 0:
+                {
+                    //
+                    // Fills in the static plug to OScalarProperty OR
+                    // OArrayProperty correspondence, used for the writing
+                    // below.
+                    //
+                    createUserPropertyFromMFnAttr(attr, plug, iUserProps, 0,
+                        scope, typeStr, staticPlugObjScalarVec,
+                        staticPlugObjArrayVec);
+                }
+                break;
+
+                // sampled
+                case 1:
+                // curve treat like sampled
+                case 2:
+                {
+                    //
+                    // Fill in the mPlugUserPropertyVec, used for the writing
+                    // below as well as in the write() method for animated
+                    // values.
+                    //
+                    createUserPropertyFromMFnAttr(attr, plug, iUserProps,
+                        iTimeIndex, scope, typeStr, mPlugObjScalarVec,
+                        mPlugObjArrayVec);
+                }
+                break;
+            }
+        }
+        else
+        {
+            switch (sampType)
+            {
+                // static
+                case 0:
+                {
+                    //
+                    // Fills in the plug to OArrayProperty correspondence,
+                    // used for the writing below.
+                    //
+                    createGeomPropertyFromMFnAttr(attr, plug, iArbGeom, 0,
+                        scope, typeStr, staticPlugObjArrayVec);
+                }
+                break;
+
+                // sampled
+                case 1:
+                // curve treat like sampled
+                case 2:
+                {
+                    //
+                    // mPlugObjArrayVec
+                    //
+                    // member variable used by isAnimated and when sampling
+                    // the animated data.
+                    //
+                    createGeomPropertyFromMFnAttr(attr, plug, iArbGeom,
+                        iTimeIndex, scope, typeStr, mPlugObjArrayVec);
+                }
+                break;
+            }
+        }
+    }
+
+    // write the static scalar props
+    std::vector< PlugAndObjScalar >::iterator k =
+        staticPlugObjScalarVec.begin();
+    std::vector< PlugAndObjScalar >::iterator kend =
+        staticPlugObjScalarVec.end();
+
+    for (; k != kend; k++)
+    {
+        MString propName = k->plug.partialName(0, 0, 0, 0, 0, 1);
+
+        //
+        // attributeTo[Scalar|Array]PropertyPair does the writing.
+        bool filledProp = attributeToScalarPropertyPair(k->obj, k->plug,
+            k->prop);
+
+        if (!filledProp)
+        {
+            MString msg = "WARNING: Couldn't get static scalar property ";
+            msg += k->plug.partialName(1, 0, 0, 0, 1, 1);
+            msg += ", so skipping.";
+            MGlobal::displayWarning(msg);
+            continue;
+        }
+    }
+
+    // write the static array props
+    std::vector< PlugAndObjArray >::iterator j =
+        staticPlugObjArrayVec.begin();
+    std::vector< PlugAndObjArray >::iterator jend =
+        staticPlugObjArrayVec.end();
+
+    for (; j != jend; j++)
+    {
+        MString propName = j->plug.partialName(0, 0, 0, 0, 0, 1);
+        bool filledProp = attributeToArrayPropertyPair(j->obj, j->plug,
+            j->prop);
+
+        if (!filledProp)
+        {
+            MString msg = "WARNING: Couldn't get static array property ";
+            msg += j->plug.partialName(1, 0, 0, 0, 1, 1);
+            msg += ", so skipping.";
+            MGlobal::displayWarning(msg);
+            continue;
+        }
+    }
+
+    // write the animated userProperties
+    k = mPlugObjScalarVec.begin();
+    kend = mPlugObjScalarVec.end();
+
+    for (; k != kend; ++k)
+    {
+        MString propName = k->plug.partialName(0, 0, 0, 0, 0, 1);
+
+        bool filledProp = attributeToScalarPropertyPair(k->obj, k->plug,
+            k->prop);
+
+        if (!filledProp)
+        {
+            MString msg = "WARNING: Couldn't get scalar property ";
+            msg += k->plug.partialName(1, 0, 0, 0, 1, 1);
+            msg += ", so skipping.";
+            MGlobal::displayWarning(msg);
+            continue;
+        }
+    }
+
+    // write the animated arbGeomProps
+    j = mPlugObjArrayVec.begin();
+    jend = mPlugObjArrayVec.end();
+    for (; j != jend; j++)
+    {
+        MString propName = j->plug.partialName(0, 0, 0, 0, 0, 1);
+        bool filledProp = attributeToArrayPropertyPair(j->obj, j->plug,j->prop);
+
+        if (!filledProp)
+        {
+            MString msg = "WARNING: Couldn't get array property ";
+            msg += j->plug.partialName(1, 0, 0, 0, 1, 1);
+            msg += ", so skipping.";
+            MGlobal::displayWarning(msg);
+            continue;
+        }
+    }
+}
+
+//
+// Returns true if the attribute is:
+//
+// * Included by name via a "attribute" or "userattribute" argument
+// * Matches by name via a "attributeprefix" or "userattributeprefix" argument
+//
+// If it's matched via "userattribute" or "userattributeprefix",
+// userAttrOut is set to true.
+// These are intended to go in the .userProperties bucket on the
+// object.
+//
+bool AttributesWriter::matchFilterOrAttribs(const MPlug & iPlug,
+                                            const AlembicWriteJob & iWriteJob,
+                                            bool& userAttrOut)
+{
+
+    MString propName = iPlug.partialName(0, 0, 0, 0, 0, 1);
+    std::string name = propName.asChar();
+
+    if (name.find("[") != std::string::npos)
+    {
+        return false;
+    }
+
+    // For .arbGeomParam bucket
+    std::vector<std::string>::const_iterator f;
+    std::vector<std::string>::const_iterator fEnd =
+        iWriteJob.GetPrefixFilters().end();
+    for (f = iWriteJob.GetPrefixFilters().begin(); f != fEnd; ++f)
+    {
+        // check the prefilter and ignore those that match but end with
+        // arb attr
+        if (f->length() > 0 &&
+            name.compare(0, f->length(), *f) == 0 &&
+            !endsWithArbAttr(name) &&
+            ( !iPlug.isChild() || !isDataAttr(iPlug.parent()) ))
+        {
+            userAttrOut = false;
+            return true;
+        }
+    }
+
+    //
+    // For .userProperties bucket
+    std::vector<std::string>::const_iterator it;
+    std::vector<std::string>::const_iterator itEnd =
+        iWriteJob.GetUserPrefixFilters().end();
+    for (it = iWriteJob.GetUserPrefixFilters().begin(); it != itEnd; ++it)
+    {
+        // check the userprefilter and ignore those that match but end with
+        // arb attr
+        if (it->length() > 0 &&
+            name.compare(0, it->length(), *it) == 0 &&
+            !endsWithArbAttr(name) &&
+            ( !iPlug.isChild() || !isDataAttr(iPlug.parent()) ))
+        {
+            userAttrOut = true;
+            return true;
+        }
+    }
+
+    // check our specific list of attributes
+    if (iWriteJob.GetAttributes().find(name) != iWriteJob.GetAttributes().end())
+    {
+        userAttrOut = false;
+        return true;
+    }
+
+    if (iWriteJob.GetUserAttributes().find(name) != iWriteJob.GetUserAttributes().end())
+    {
+        userAttrOut = true;
+        return true;
+    }
+
+    return false;
+}
+
+bool AttributesWriter::hasAnyAttr(const MFnDependencyNode & iNode,
+                                  const AlembicWriteJob & iWriteJob)
+{
+    unsigned int attrCount = iNode.attributeCount();
+    unsigned int i;
+
+    std::vector< PlugAndObjArray > staticPlugObjArrayVec;
+
+    bool userAttr;
+    for (i = 0; i < attrCount; i++)
+    {
+        MObject attr = iNode.attribute(i);
+        MFnAttribute mfnAttr(attr);
+        MPlug plug = iNode.findPlug(attr, true);
+
+        // if it is not readable, then bail without any more checking
+        if (!mfnAttr.isReadable() || plug.isNull())
+        {
+            continue;
+        }
+
+        if (matchFilterOrAttribs(plug, iWriteJob, userAttr))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+AttributesWriter::~AttributesWriter()
+{
+}
+
+bool AttributesWriter::isAnimated()
+{
+    return !mPlugObjArrayVec.empty() || !mAnimVisibility.plug.isNull() ||
+           !mPlugObjScalarVec.empty();
+}
+
+void AttributesWriter::write()
+{
+
+    std::vector< PlugAndObjArray >::iterator j =
+        mPlugObjArrayVec.begin();
+    std::vector< PlugAndObjArray >::iterator jend =
+        mPlugObjArrayVec.end();
+
+    for (; j != jend; j++)
+    {
+        MString propName = j->plug.partialName(0, 0, 0, 0, 0, 1);
+        bool filledProp = attributeToArrayPropertyPair(j->obj, j->plug, j->prop);
+
+        if (!filledProp)
+        {
+            MString msg = "WARNING: Couldn't get sampled array property ";
+            msg += j->plug.partialName(1, 0, 0, 0, 1, 1);
+            msg += ", so skipping.";
+            MGlobal::displayWarning(msg);
+            continue;
+        }
+    }
+
+    std::vector< PlugAndObjScalar >::iterator k =
+        mPlugObjScalarVec.begin();
+    std::vector< PlugAndObjScalar >::iterator kend =
+        mPlugObjScalarVec.end();
+
+    for (; k != kend; ++k)
+    {
+        MString propName = k->plug.partialName(0, 0, 0, 0, 0, 1);
+
+        bool filledProp = attributeToScalarPropertyPair(k->obj, k->plug,
+            k->prop);
+
+        if (!filledProp)
+        {
+            MString msg = "WARNING: Couldn't get sampled scalar property ";
+            msg += k->plug.partialName(1, 0, 0, 0, 1, 1);
+            msg += ", so skipping.";
+            MGlobal::displayWarning(msg);
+            continue;
+        }
+    }
+
+    if (!mAnimVisibility.plug.isNull())
+    {
+        Alembic::Util::int8_t visVal = -1;
+        if (!mAnimVisibility.plug.asBool())
+        {
+            visVal = 0;
+        }
+
+        mAnimVisibility.prop.set(&visVal);
+    }
+
+}
+
+

--- a/Maya/AttributesWriter.h
+++ b/Maya/AttributesWriter.h
@@ -1,0 +1,80 @@
+//-*****************************************************************************
+//
+// Copyright (c) 2009-2012,
+//  Sony Pictures Imageworks Inc. and
+//  Industrial Light & Magic, a division of Lucasfilm Entertainment Company Ltd.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+// *       Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// *       Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+// *       Neither the name of Sony Pictures Imageworks, nor
+// Industrial Light & Magic, nor the names of their contributors may be used
+// to endorse or promote products derived from this software without specific
+// prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//-*****************************************************************************
+
+#ifndef _maya2hdf_AttributesWriter_h_
+#define _maya2hdf_AttributesWriter_h_
+
+#include "AlembicWriteJob.h"
+#include "MayaUtility.h"
+
+// class which holds a mapping of sampled attribute names to the attribute
+// plugs and will fill in the property map on various HDF nodes
+class AttributesWriter
+{
+  public:
+    // fills in the property maps for both static and sampled, and does
+    // the initial write at iFrame for sampled data
+    AttributesWriter(Alembic::Abc::OCompoundProperty & iArgGeom,
+                     Alembic::Abc::OCompoundProperty & iUserProps,
+                     Alembic::Abc::OObject & iParentObj,
+                     const MFnDependencyNode & iNode,
+                     Alembic::Util::uint32_t iTimeIndex,
+                     const AlembicWriteJob & iWriteJob);
+
+    ~AttributesWriter();
+
+    void write();
+    bool isAnimated();
+
+    static bool matchFilterOrAttribs(const MPlug & iPlug,
+                                     const AlembicWriteJob & iWriteJob,
+                                     bool& userAttrOut);
+
+    static bool hasAnyAttr(const MFnDependencyNode & iNode,
+                           const AlembicWriteJob & iWriteJob);
+
+  private:
+
+    std::vector < PlugAndObjArray >     mPlugObjArrayVec;
+    std::vector < PlugAndObjScalar >    mPlugObjScalarVec;
+
+    // animated visibility plug
+    PlugAndObjScalar mAnimVisibility;
+};
+
+typedef Alembic::Util::shared_ptr<AttributesWriter> AttributesWriterPtr;
+
+#endif  // _maya2hdf_AttributesWriter_h_

--- a/Maya/CMakeLists.txt
+++ b/Maya/CMakeLists.txt
@@ -17,7 +17,9 @@ include_directories( ${BASE_DIR}/include )
 include_directories( ${BASE_DIR}/src )
 
 file(GLOB_RECURSE Sources ${BASE_DIR}/*.cpp)
+list(REMOVE_ITEM Sources ${BASE_DIR}/stdafx.cpp)
 file(GLOB_RECURSE Includes ${BASE_DIR}/*.h)
+list(REMOVE_ITEM Includes ${BASE_DIR}/stdafx.h)
 
 file(GLOB_RECURSE Scripts ${BASE_DIR}/MEL/*.*)
 file(GLOB_RECURSE UI ${BASE_DIR}/UI/*.*)
@@ -27,7 +29,7 @@ SOURCE_GROUP("Header Files" FILES ${Includes})
 SOURCE_GROUP("_MEL" FILES ${Scripts})
 SOURCE_GROUP("_UI" FILES ${UI}) 
 
-setup_precompiled_header( ${BASE_DIR} ${Sources} )
+setup_precompiled_header( ${BASE_DIR} Sources )
 
 IF( WIN32 )
 

--- a/Maya/MEL/ExocortexAlembic/_attach.py
+++ b/Maya/MEL/ExocortexAlembic/_attach.py
@@ -17,117 +17,147 @@ def attachTimeAndFile(node, jobInfo, isConstant=False):
 
 def attachXform(name, identifier, jobInfo, isConstant=False):
 	cmds.ExocortexAlembic_profileBegin(f="Python.ExocortexAlembic._attach.attachXform")
-	conX = cmds.listConnections(name+".translate")
-	if conX:
-		# already receiving transformation from another node!
-		conX = conX[0]
-		if cmds.objectType(conX) == "ExocortexAlembicXform":
-			attachTimeAndFile(conX, jobInfo, isConstant)
-		else:
-			print("Cannot attach Xform to " + name + ", it's attach to a node that is not an \"ExocortexAlembicXform\"")
-		return
+	result = "No error"
+	try:
+		conX = cmds.listConnections(name+".translate")
+		if conX:
+			# already receiving transformation from another node!
+			conX = conX[0]
+			if cmds.objectType(conX) == "ExocortexAlembicXform":
+				attachTimeAndFile(conX, jobInfo, isConstant)
+				return "Attached existing"
+			else:
+				return "Cannot attach Xform to " + name + ", it's attach to a node that is not an \"ExocortexAlembicXform\""
 
-	newXform = cmds.createNode("ExocortexAlembicXform")
-	cmds.setAttr(newXform+".identifier", identifier, type="string")
-	cmds.connectAttr(newXform+".translate", 	name+".translate")
-	cmds.connectAttr(newXform+".rotate",		name+".rotate")
-	cmds.connectAttr(newXform+".scale", 		name+".scale")
-	cmds.connectAttr(newXform+".outVisibility",	name+".visibility")
+		newXform = cmds.createNode("ExocortexAlembicXform")
+		cmds.setAttr(newXform+".identifier", identifier, type="string")
+		cmds.connectAttr(newXform+".translate", 	name+".translate")
+		cmds.connectAttr(newXform+".rotate",		name+".rotate")
+		cmds.connectAttr(newXform+".scale", 		name+".scale")
+		cmds.connectAttr(newXform+".outVisibility",	name+".visibility")
 
-	attachTimeAndFile(newXform, jobInfo, isConstant)
+		attachTimeAndFile(newXform, jobInfo, isConstant)
+	except:
+		import traceback
+		result = traceback.format_exc()
+
 	cmds.ExocortexAlembic_profileEnd(f="Python.ExocortexAlembic._attach.attachXform")
-	pass
+	return result
 
 def attachPolyMesh(name, identifier, jobInfo, isConstant=False):
 	cmds.ExocortexAlembic_profileBegin(f="Python.ExocortexAlembic._attach.attachPolyMesh")
-	if cmds.objectType(name) != "mesh":
-		print("Only mesh can be attached too!")
-		cmds.ExocortexAlembic_profileEnd(f="Python.ExocortexAlembic._attach.attachPolyMesh")
-		return
+	result = "No error"
+	try:
+		if not cmds.objExists(name) and cmds.objExists(name + "Deformed"):
+			name = name + "Deformed"
 
-	polyObj = cmds.connectionInfo(name+".inMesh", sfd=True).split('.')[0]					# cmds.plugNode doesn't exist!
-	if polyObj and cmds.objectType(polyObj) == "ExocortexAlembicPolyMeshDeform":	# it's already attached to a deform, simply change the file reference
-		attachTimeAndFile(polyObj, jobInfo, isConstant)
-		return
+		if cmds.objectType(name) != "mesh":
+			cmds.ExocortexAlembic_profileEnd(f="Python.ExocortexAlembic._attach.attachPolyMesh")
+			return "Only mesh can be attached too!"
 
-	# create deformer, and attach time and file
-	newDform = cmds.deformer(name, type="ExocortexAlembicPolyMeshDeform")[0]
-	cmds.setAttr(newDform+".identifier", identifier, type="string")
-	attachTimeAndFile(newDform, jobInfo, isConstant)
+		polyObj = cmds.connectionInfo(name+".inMesh", sfd=True).split('.')[0]					# cmds.plugNode doesn't exist!
+		if polyObj and cmds.objectType(polyObj) == "ExocortexAlembicPolyMeshDeform":	# it's already attached to a deform, simply change the file reference
+			attachTimeAndFile(polyObj, jobInfo, isConstant)
+			cmds.ExocortexAlembic_profileEnd(f="Python.ExocortexAlembic._attach.attachPolyMesh")
+			return "Connected existing"
 
-	if jobInfo.useFaceSets:
-		cmds.ExocortexAlembic_createFaceSets(f=cmds.getAttr(jobInfo.filenode+".outFileName"), i=identifier, o=name)
+		# create deformer, and attach time and file
+		newDform = cmds.deformer(name, type="ExocortexAlembicPolyMeshDeform")[0]
+		cmds.setAttr(newDform+".identifier", identifier, type="string")
+		attachTimeAndFile(newDform, jobInfo, isConstant)
+
+		if jobInfo.useFaceSets:
+			cmds.ExocortexAlembic_createFaceSets(f=cmds.getAttr(jobInfo.filenode+".outFileName"), i=identifier, o=name)
+	except:
+		import traceback
+		result = traceback.format_exc()
 
 	cmds.ExocortexAlembic_profileEnd(f="Python.ExocortexAlembic._attach.attachPolyMesh")
-	pass
+	return result
 
 def attachCamera(name, identifier, jobInfo, isConstant=False):
 	cmds.ExocortexAlembic_profileBegin(f="Python.ExocortexAlembic._attach.attachCamera")
-	camObj = cmds.connectionInfo(name+".focalLength", sfd=True)
-	if camObj and cmds.objectType(camObj) == "ExocortexAlembicCamera":
-		attachTimeAndFile(camObj, jobInfo, isConstant)
-		return
+	result = "No error"
+	try:
+		camObj = cmds.connectionInfo(name+".focalLength", sfd=True)
+		if camObj and cmds.objectType(camObj) == "ExocortexAlembicCamera":
+			attachTimeAndFile(camObj, jobInfo, isConstant)
+			return "Attached existing"
 
-	reader = cmds.createNode("ExocortexAlembicCamera")
-	cmds.connectAttr(reader+".focalLength", name+".focalLength")
-	cmds.connectAttr(reader+".focusDistance", name+".focusDistance")
-	cmds.connectAttr(reader+".lensSqueezeRatio", name+".lensSqueezeRatio")
-	cmds.connectAttr(reader+".horizontalFilmAperture", name+".horizontalFilmAperture")
-	cmds.connectAttr(reader+".verticalFilmAperture", name+".verticalFilmAperture")
-	cmds.connectAttr(reader+".horizontalFilmOffset", name+".horizontalFilmOffset")
-	cmds.connectAttr(reader+".verticalFilmOffset", name+".verticalFilmOffset")
-	cmds.connectAttr(reader+".fStop", name+".fStop")
-	cmds.connectAttr(reader+".shutterAngle", name+".shutterAngle")
+		reader = cmds.createNode("ExocortexAlembicCamera")
+		cmds.connectAttr(reader+".focalLength", name+".focalLength")
+		cmds.connectAttr(reader+".focusDistance", name+".focusDistance")
+		cmds.connectAttr(reader+".lensSqueezeRatio", name+".lensSqueezeRatio")
+		cmds.connectAttr(reader+".horizontalFilmAperture", name+".horizontalFilmAperture")
+		cmds.connectAttr(reader+".verticalFilmAperture", name+".verticalFilmAperture")
+		cmds.connectAttr(reader+".horizontalFilmOffset", name+".horizontalFilmOffset")
+		cmds.connectAttr(reader+".verticalFilmOffset", name+".verticalFilmOffset")
+		cmds.connectAttr(reader+".fStop", name+".fStop")
+		cmds.connectAttr(reader+".shutterAngle", name+".shutterAngle")
 
-	attachTimeAndFile(reader, jobInfo, isConstant)
+		attachTimeAndFile(reader, jobInfo, isConstant)
+	except:
+		import traceback
+		result = traceback.format_exc()
+
 	cmds.ExocortexAlembic_profileEnd(f="Python.ExocortexAlembic._attach.attachCamera")
-	pass
+	return result
 
 def attachCurves(name, identifier, jobInfo, isConstant=False):
 	cmds.ExocortexAlembic_profileBegin(f="Python.ExocortexAlembic._attach.attachCurves")
-	curObj = cmds.connectionInfo(name+".visibility", sfd=True)
-	if curObj and cmds.objectType(curObj) == "ExocortexAlembicCurvesDeform":
-		attachTimeAndFile(curObj, jobInfo, isConstant)
-		return
+	result = "No error"
+	try:
+		curObj = cmds.connectionInfo(name+".visibility", sfd=True)
+		if curObj and cmds.objectType(curObj) == "ExocortexAlembicCurvesDeform":
+			attachTimeAndFile(curObj, jobInfo, isConstant)
+			return "Attached existing"
 
-	# create deformer, and attach time and file
-	newDform = cmds.deformer(name, type="ExocortexAlembicCurvesDeform")[0]
-	cmds.setAttr(newDform+".identifier", identifier, type="string")
-	attachTimeAndFile(newDform, jobInfo, isConstant)
+		# create deformer, and attach time and file
+		newDform = cmds.deformer(name, type="ExocortexAlembicCurvesDeform")[0]
+		cmds.setAttr(newDform+".identifier", identifier, type="string")
+		attachTimeAndFile(newDform, jobInfo, isConstant)
 
-  	# get curObj new "output" attribute connection
-  	if curObj and cmds.objectType(curObj) != "ExocortexAlembicCurves":
-  		originalCur = cmds.connectionInfo(curObj+".output", sfd=True).split('.')[0]
+		# get curObj new "output" attribute connection
+		if curObj and cmds.objectType(curObj) != "ExocortexAlembicCurves":
+			originalCur = cmds.connectionInfo(curObj+".output", sfd=True).split('.')[0]
 
-  		cmds.delete(curObj)
-  		curObj = cmds.createNode("ExocortexAlembicCurves")
-  		attachTimeAndFile(curObj, jobInfo, isConstant)
+			cmds.delete(curObj)
+			curObj = cmds.createNode("ExocortexAlembicCurves")
+			attachTimeAndFile(curObj, jobInfo, isConstant)
 
 		cmds.connectAttr(curObj+".outCurve", originalCur+".create")
 		cmds.connectAttr(jobInfo.filenode+".outFileName", curObj+".fileName")
 		cmds.setAttr(curObj+".identifier", identifier, type="string")
+	except:
+		import traceback
+		result = traceback.format_exc()
 
 	cmds.ExocortexAlembic_profileEnd(f="Python.ExocortexAlembic._attach.attachCurves")
-	pass
+	return result
 
 def attachPoints(name, identifier, jobInfo, isConstant=False):
 	cmds.ExocortexAlembic_profileBegin(f="Python.ExocortexAlembic._attach.attachPoints")
-	ptsObj = cmds.connectionInfo(name+".visibility", sfd=True)
-	if ptsObj and cmds.objectType(ptsObj) == "ExocortexAlembicPoints":
-		attachTimeAndFile(ptsObj, jobInfo, isConstant)
-		return
+	result = "No error"
+	try:
+		ptsObj = cmds.connectionInfo(name+".visibility", sfd=True)
+		if ptsObj and cmds.objectType(ptsObj) == "ExocortexAlembicPoints":
+			attachTimeAndFile(ptsObj, jobInfo, isConstant)
+			return "Attached existing"
 
-	reader = cmds.createNode("ExocortexAlembicPoints")
-	cmds.addAttr(name, ln="rgbPP", dt="vectorArray")
-	cmds.addAttr(name, ln="opacityPP", dt="doubleArray")
-	cmds.addAttr(name, ln="agePP", dt="doubleArray")
-	cmds.addAttr(name, ln="shapeInstanceIdPP", dt="doubleArray")
-	cmds.addAttr(name, ln="orientationPP", dt="vectorArray")
-	cmds.connectAttr(reader+".output[0]", name+".newParticles[0]")
-	cmds.connectAttr(jobInfo.timeCtrl+".outTime", name+".currentTime")
-	cmds.setAttr(name+".conserve", 0)
+		reader = cmds.createNode("ExocortexAlembicPoints")
+		cmds.addAttr(name, ln="rgbPP", dt="vectorArray")
+		cmds.addAttr(name, ln="opacityPP", dt="doubleArray")
+		cmds.addAttr(name, ln="agePP", dt="doubleArray")
+		cmds.addAttr(name, ln="shapeInstanceIdPP", dt="doubleArray")
+		cmds.addAttr(name, ln="orientationPP", dt="vectorArray")
+		cmds.connectAttr(reader+".output[0]", name+".newParticles[0]")
+		cmds.connectAttr(jobInfo.timeCtrl+".outTime", name+".currentTime")
+		cmds.setAttr(name+".conserve", 0)
 
-	attachTimeAndFile(reader, jobInfo, isConstant)
+		attachTimeAndFile(reader, jobInfo, isConstant)
+	except:
+		import traceback
+		result = traceback.format_exc()
 	cmds.ExocortexAlembic_profileEnd(f="Python.ExocortexAlembic._attach.attachPoints")
-	pass
+	return result
 

--- a/Maya/MEL/ExocortexAlembic/_export.py
+++ b/Maya/MEL/ExocortexAlembic/_export.py
@@ -2,7 +2,7 @@ import maya.cmds as cmds
 
 """ Export module of Exocortex Crate """
 
-def doIt(filename, exInframe, exOutframe, exObjects=None, exStepframe=1, exSubstepframe=1, exTopology=3, exUVs=True, exFaceSets=True, exDynTopo=False, exGlobSpace=False, exWithoutHierarchy=False, exXformCache=False, exUseInitShadGrp=False, exUseOgawa=False):
+def doIt(filename, exInframe, exOutframe, exObjects=None, exStepframe=1, exSubstepframe=1, exTopology=3, exUVs=True, exFaceSets=True, exDynTopo=False, exGlobSpace=False, exWithoutHierarchy=False, exXformCache=False, exUseInitShadGrp=False, exUseOgawa=False, userAttrs="", userAttrPrefixes=""):
 	"""
 	Set up the string parameter for ExocortexAlembic_export
 	"""
@@ -35,6 +35,11 @@ def doIt(filename, exInframe, exOutframe, exObjects=None, exStepframe=1, exSubst
 	job += ";globalspace="+str(int(exGlobSpace))
 	job += ";withouthierarchy="+str(int(exWithoutHierarchy))
 	job += ";transformcache="+str(int(exXformCache))
+
+	if userAttrs:
+		job += ";userattrs="+str(userAttrs)
+	if userAttrPrefixes:
+		job += ";userattrprefixes="+str(userAttrPrefixes)
 
 	cmds.ExocortexAlembic_export(j=job)
 	cmds.ExocortexAlembic_profileEnd(f="Python.ExocortexAlembic._export.doIt")

--- a/Maya/MEL/ExocortexAlembic/_import.py
+++ b/Maya/MEL/ExocortexAlembic/_import.py
@@ -1,3 +1,5 @@
+import traceback
+
 import maya.cmds as cmds
 import maya.OpenMayaMPx as apix
 import _functions as fnt
@@ -29,13 +31,17 @@ def setupReaderAttribute(reader, identifier, isConstant, jobInfo):
 				fnt.alembicConnectAttr(jobInfo.timeCtrl+".outTime", reader+".inTime")
 			cmds.connectAttr(jobInfo.filenode+".outFileName", reader+".fileName")
 			cmds.setAttr(reader+".identifier", identifier, type="string")
-	except Exception as ex:
-		apix.MPxCommand.setResult("?setupReaderAttribute --> exception: \"" + str(ex.args) + "\" of type " + str(type(ex)))
-	cmds.ExocortexAlembic_profileEnd(f="Python.ExocortexAlembic._import.setupReaderAttribute")
+	except:
+		raise
+	finally:
+		cmds.ExocortexAlembic_profileEnd(f="Python.ExocortexAlembic._import.setupReaderAttribute")
 
 def importXform(name, identifier, jobInfo, parentXform=None, isConstant=False):
 	cmds.ExocortexAlembic_profileBegin(f="Python.ExocortexAlembic._import.importXform")
 
+	# TODO: set isConstant properly elsewhere when there are no transforms but are
+	# animated attributes
+	isConstant = False
 	try:
 		shape  = fnt.alembicCreateNode(name, "transform", parentXform)
 		reader = cmds.createNode("ExocortexAlembicXform")
@@ -46,15 +52,18 @@ def importXform(name, identifier, jobInfo, parentXform=None, isConstant=False):
 		cmds.connectAttr(reader+".outVisibility",	shape+".visibility")
 
 		setupReaderAttribute(reader, identifier, isConstant, jobInfo)
-	except Exception as ex:
-		shape = "?importXform --> exception: \"" + str(ex.args) + "\" of type " + str(type(ex));
-		apix.MPxCommand.setResult(shape)
-	cmds.ExocortexAlembic_profileEnd(f="Python.ExocortexAlembic._import.importXform")
-	return shape
+	except:
+		return [traceback.format_exc()]
+	finally:
+		cmds.ExocortexAlembic_profileEnd(f="Python.ExocortexAlembic._import.importXform")
+	return [shape, reader]
 
 def importPolyMesh(name, identifier, jobInfo, parentXform=None, isConstant=False, useDynTopo=False):
 	cmds.ExocortexAlembic_profileBegin(f="Python.ExocortexAlembic._import.importPolyMesh")
 
+	# TODO: set isConstant properly elsewhere when there are no transforms but are
+	# animated attributes
+	isConstant = False
 	try:
 		reader = ""
 		shape  = fnt.alembicCreateNode(name, "mesh", parentXform)
@@ -79,14 +88,17 @@ def importPolyMesh(name, identifier, jobInfo, parentXform=None, isConstant=False
 		#if not useDynTopo:
 		#	setupReaderAttribute(topoReader, identifier, isConstant, jobInfo)
 
-	except Exception as ex:
-		shape = "?importPolyMesh --> exception: \"" + str(ex.args) + "\" of type " + str(type(ex));
-		apix.MPxCommand.setResult(shape)
-	cmds.ExocortexAlembic_profileEnd(f="Python.ExocortexAlembic._import.importPolyMesh")
-	return shape
+	except:
+		return [traceback.format_exc()]
+	finally:
+		cmds.ExocortexAlembic_profileEnd(f="Python.ExocortexAlembic._import.importPolyMesh")
+	return [shape, reader]
 
 def importCamera(name, identifier, jobInfo, parentXform=None, isConstant=False):
 	cmds.ExocortexAlembic_profileBegin(f="Python.ExocortexAlembic._import.importCamera")
+	# TODO: set isConstant properly elsewhere when there are no transforms but are
+	# animated attributes
+	isConstant = False
 	try:
 		shape 	= fnt.alembicCreateNode(name, "camera", parentXform)
 		reader 	= cmds.createNode("ExocortexAlembicCamera")
@@ -102,13 +114,16 @@ def importCamera(name, identifier, jobInfo, parentXform=None, isConstant=False):
 		cmds.connectAttr(reader+".shutterAngle", shape+".shutterAngle")
 
 		setupReaderAttribute(reader, identifier, isConstant, jobInfo)
-	except Exception as ex:
-		shape = "?importCamera --> exception: \"" + str(ex.args) + "\" of type " + str(type(ex));
-		apix.MPxCommand.setResult(shape)
-	cmds.ExocortexAlembic_profileEnd(f="Python.ExocortexAlembic._import.importCamera")
-	return shape
+	except:
+		return [traceback.format_exc()]
+	finally:
+		cmds.ExocortexAlembic_profileEnd(f="Python.ExocortexAlembic._import.importCamera")
+	return [shape, reader]
 
 def importPoints(name, identifier, jobInfo, parentXform=None, isConstant=False):
+	# TODO: set isConstant properly elsewhere when there are no transforms but are
+	# animated attributes
+	isConstant = False
 	try:
 		cmds.ExocortexAlembic_profileBegin(f="Python.ExocortexAlembic._import.importPoints")
 		shape  = fnt.alembicCreateNode(name, "particle", parentXform)
@@ -124,14 +139,17 @@ def importPoints(name, identifier, jobInfo, parentXform=None, isConstant=False):
 		cmds.setAttr(shape+".conserve", 0)
 
 		setupReaderAttribute(reader, identifier, isConstant, jobInfo)
-	except Exception as ex:
-		shape = "?importPoints --> exception: \"" + str(ex.args) + "\" of type " + str(type(ex));
-		apix.MPxCommand.setResult(shape)
-	cmds.ExocortexAlembic_profileEnd(f="Python.ExocortexAlembic._import.importPoints")
-	return shape
+	except:
+		return [traceback.format_exc()]
+	finally:
+		cmds.ExocortexAlembic_profileEnd(f="Python.ExocortexAlembic._import.importPoints")
+	return [shape, reader]
 
 def importCurves(name, identifier, jobInfo, parentXform=None, isConstant=False, nbCurves=1):
 	cmds.ExocortexAlembic_profileBegin(f="Python.ExocortexAlembic._import.importCurves")
+	# TODO: set isConstant properly elsewhere when there are no transforms but are
+	# animated attributes
+	isConstant = False
 	try:
 		topoReader = cmds.createNode("ExocortexAlembicCurves")
 		cmds.connectAttr(jobInfo.filenode+".outFileName", topoReader+".fileName")
@@ -144,10 +162,10 @@ def importCurves(name, identifier, jobInfo, parentXform=None, isConstant=False, 
 			shape  = fnt.alembicCreateNode(name + "_" + str(curve), "nurbsCurve", parentXform)
 			cmds.connectAttr(topoReader+".outCurve[" + str(curve) + "]", shape+".create")
 
-	except Exception as ex:
-		shape = "?importCurves --> exception: \"" + str(ex.args) + "\" of type " + str(type(ex));
-		apix.MPxCommand.setResult(shape)
-	cmds.ExocortexAlembic_profileEnd(f="Python.ExocortexAlembic._import.importCurves")
-	return shape
+	except:
+		return [traceback.format_exc()]
+	finally:
+		cmds.ExocortexAlembic_profileEnd(f="Python.ExocortexAlembic._import.importCurves")
+	return [shape, topoReader]
 
 

--- a/Maya/MEL/export.mel
+++ b/Maya/MEL/export.mel
@@ -21,6 +21,8 @@ global proc exocortexAlembicExportGUI(string $filename, string $dialog)
   int $exportWithoutHierarchy = `checkBox -q -value withouthierarchy`;
   int $exportTransformCache = `checkBox -q -value transformcache`;
   int $exportOgawa = `optionMenu -q -select database`;
+  string $userAttrs = `textField -q -text userattrs`;
+  string $userAttrPrefixes = `textField -q -text userattrprefixes`;
   exocortexCloseDialog($dialog);
 
   $minTime = `playbackOptions -q -min`;
@@ -60,7 +62,8 @@ global proc exocortexAlembicExportGUI(string $filename, string $dialog)
                          $exportStepframe + ", " + $exportSubstepframe + ", " + $exportTopology + ", " +
                          $exportUVs + ", " + $exportFaceSets + ", " + $exportDynamicTopo + ", " +
                          $exportGlobalSpace + ", " + $exportWithoutHierarchy + ", " + $exportTransformCache + ", " +
-                         $exportUseInitShadGrp + ", " + ($exportOgawa-1) + ")";
+                         $exportUseInitShadGrp + ", " + ($exportOgawa-1) + ", \"" +
+                         $userAttrs + "\", \"" + $userAttrPrefixes + "\")";
   python($cmd);
 }
 

--- a/Maya/MayaUtility.cpp
+++ b/Maya/MayaUtility.cpp
@@ -1,0 +1,611 @@
+//-*****************************************************************************
+//
+// Copyright (c) 2009-2012,
+//  Sony Pictures Imageworks Inc. and
+//  Industrial Light & Magic, a division of Lucasfilm Entertainment Company Ltd.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+// *       Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// *       Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+// *       Neither the name of Sony Pictures Imageworks, nor
+// Industrial Light & Magic, nor the names of their contributors may be used
+// to endorse or promote products derived from this software without specific
+// prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//-*****************************************************************************
+#include "stdafx.h"
+
+#include "MayaUtility.h"
+
+#include <maya/MAnimUtil.h>
+#include <maya/MFnExpression.h>
+#include <maya/MItDependencyGraph.h>
+
+// return seconds per frame
+double util::spf()
+{
+    static const MTime sec(1.0, MTime::kSeconds);
+    return 1.0 / sec.as(MTime::uiUnit());
+}
+
+bool util::isAncestorDescendentRelationship(const MDagPath & path1,
+    const MDagPath & path2)
+{
+    unsigned int length1 = path1.length();
+    unsigned int length2 = path2.length();
+    unsigned int diff;
+
+    if (length1 == length2 && !(path1 == path2))
+        return false;
+
+    MDagPath ancestor, descendent;
+    if (length1 > length2)
+    {
+        ancestor = path2;
+        descendent = path1;
+        diff = length1 - length2;
+    }
+    else
+    {
+        ancestor = path1;
+        descendent = path2;
+        diff = length2 - length1;
+    }
+
+    descendent.pop(diff);
+
+    bool ret = (ancestor == descendent);
+
+    if (ret)
+    {
+        MString err = path1.fullPathName() + " and ";
+        err += path2.fullPathName() + " have parenting relationships";
+        MGlobal::displayError(err);
+    }
+    return ret;
+}
+
+
+
+// returns 0 if static, 1 if sampled, and 2 if a curve
+int util::getSampledType(const MPlug& iPlug)
+{
+    MPlugArray conns;
+
+    iPlug.connectedTo(conns, true, false);
+
+    // it's possible that only some element of an array plug or
+    // some component of a compound plus is connected
+    if (conns.length() == 0)
+    {
+        if (iPlug.isArray())
+        {
+            unsigned int numConnectedElements = iPlug.numConnectedElements();
+            for (unsigned int e = 0; e < numConnectedElements; e++)
+            {
+                int retVal = getSampledType(iPlug.connectionByPhysicalIndex(e));
+                if (retVal > 0)
+                    return retVal;
+            }
+        }
+        else if (iPlug.isCompound() && iPlug.numConnectedChildren() > 0)
+        {
+            unsigned int numChildren = iPlug.numChildren();
+            for (unsigned int c = 0; c < numChildren; c++)
+            {
+                int retVal = getSampledType(iPlug.child(c));
+                if (retVal > 0)
+                    return retVal;
+            }
+        }
+        return 0;
+    }
+
+    MObject ob;
+    MFnDependencyNode nodeFn;
+    for (unsigned i = 0; i < conns.length(); i++)
+    {
+        ob = conns[i].node();
+        MFn::Type type = ob.apiType();
+
+        switch (type)
+        {
+            case MFn::kAnimCurveTimeToAngular:
+            case MFn::kAnimCurveTimeToDistance:
+            case MFn::kAnimCurveTimeToTime:
+            case MFn::kAnimCurveTimeToUnitless:
+            {
+                nodeFn.setObject(ob);
+                MPlug incoming = nodeFn.findPlug("i", true);
+
+                // sampled
+                if (incoming.isConnected())
+                    return 1;
+
+                // curve
+                else
+                    return 2;
+            }
+            break;
+
+            case MFn::kMute:
+            {
+                nodeFn.setObject(ob);
+                MPlug mutePlug = nodeFn.findPlug("mute", true);
+
+                // static
+                if (mutePlug.asBool())
+                    return 0;
+                // curve
+                else
+                   return 2;
+            }
+            break;
+
+            default:
+            break;
+        }
+    }
+
+    return 1;
+}
+
+bool util::getRotOrder(MTransformationMatrix::RotationOrder iOrder,
+    unsigned int & oXAxis, unsigned int & oYAxis, unsigned int & oZAxis)
+{
+    switch (iOrder)
+    {
+        case MTransformationMatrix::kXYZ:
+        {
+            oXAxis = 0;
+            oYAxis = 1;
+            oZAxis = 2;
+        }
+        break;
+
+        case MTransformationMatrix::kYZX:
+        {
+            oXAxis = 1;
+            oYAxis = 2;
+            oZAxis = 0;
+        }
+        break;
+
+        case MTransformationMatrix::kZXY:
+        {
+            oXAxis = 2;
+            oYAxis = 0;
+            oZAxis = 1;
+        }
+        break;
+
+        case MTransformationMatrix::kXZY:
+        {
+            oXAxis = 0;
+            oYAxis = 2;
+            oZAxis = 1;
+        }
+        break;
+
+        case MTransformationMatrix::kYXZ:
+        {
+            oXAxis = 1;
+            oYAxis = 0;
+            oZAxis = 2;
+        }
+        break;
+
+        case MTransformationMatrix::kZYX:
+        {
+            oXAxis = 2;
+            oYAxis = 1;
+            oZAxis = 0;
+        }
+        break;
+
+        default:
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+// 0 dont write, 1 write static 0, 2 write anim 0, 3 write anim -1
+int util::getVisibilityType(const MPlug & iPlug)
+{
+    int type = getSampledType(iPlug);
+
+    // static case
+    if (type == 0)
+    {
+        // dont write anything
+        if (iPlug.asBool())
+            return 0;
+
+        // write static 0
+        return 1;
+    }
+    else
+    {
+        // anim write -1
+        if (iPlug.asBool())
+            return 3;
+
+        // write anim 0
+        return 2;
+    }
+}
+
+// does this cover all cases?
+bool util::isAnimated(MObject & object, bool checkParent)
+{
+    MStatus stat;
+    MItDependencyGraph iter(object, MFn::kInvalid,
+        MItDependencyGraph::kUpstream,
+        MItDependencyGraph::kDepthFirst,
+        MItDependencyGraph::kNodeLevel,
+        &stat);
+
+    if (stat!= MS::kSuccess)
+    {
+        MGlobal::displayError("Unable to create DG iterator ");
+    }
+
+    // MAnimUtil::isAnimated(node) will search the history of the node
+    // for any animation curve nodes. It will return true for those nodes
+    // that have animation curve in their history.
+    // The average time complexity is O(n^2) where n is the number of history
+    // nodes. But we can improve the best case by split the loop into two.
+    std::vector<MObject> nodesToCheckAnimCurve;
+
+    for (; !iter.isDone(); iter.next())
+    {
+        MObject node = iter.thisNode();
+
+        if (node.hasFn(MFn::kPluginDependNode) ||
+                node.hasFn( MFn::kConstraint ) ||
+                node.hasFn(MFn::kPointConstraint) ||
+                node.hasFn(MFn::kAimConstraint) ||
+                node.hasFn(MFn::kOrientConstraint) ||
+                node.hasFn(MFn::kScaleConstraint) ||
+                node.hasFn(MFn::kGeometryConstraint) ||
+                node.hasFn(MFn::kNormalConstraint) ||
+                node.hasFn(MFn::kTangentConstraint) ||
+                node.hasFn(MFn::kParentConstraint) ||
+                node.hasFn(MFn::kPoleVectorConstraint) ||
+                node.hasFn(MFn::kParentConstraint) ||
+                node.hasFn(MFn::kTime) ||
+                node.hasFn(MFn::kJoint) ||
+                node.hasFn(MFn::kGeometryFilt) ||
+                node.hasFn(MFn::kTweak) ||
+                node.hasFn(MFn::kPolyTweak) ||
+                node.hasFn(MFn::kSubdTweak) ||
+                node.hasFn(MFn::kCluster) ||
+                node.hasFn(MFn::kFluid) ||
+                node.hasFn(MFn::kPolyBoolOp))
+        {
+            return true;
+        }
+
+        if (node.hasFn(MFn::kExpression))
+        {
+            MFnExpression fn(node, &stat);
+            if (stat == MS::kSuccess && fn.isAnimated())
+            {
+                return true;
+            }
+        }
+
+        // skip shading nodes
+        if (!node.hasFn(MFn::kShadingEngine))
+        {
+            nodesToCheckAnimCurve.push_back(node);
+        }
+        else
+        {
+            // and don't traverse the rest of their subgraph
+            iter.prune();
+        }
+    }
+
+    for (size_t i = 0; i < nodesToCheckAnimCurve.size(); i++)
+    {
+        if (MAnimUtil::isAnimated(nodesToCheckAnimCurve[i], checkParent))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool util::isIntermediate(const MObject & object)
+{
+    MStatus stat;
+    MFnDagNode mFn(object);
+
+    MPlug plug = mFn.findPlug("intermediateObject", false, &stat);
+    if (stat == MS::kSuccess && plug.asBool())
+        return true;
+    else
+        return false;
+}
+
+bool util::isRenderable(const MObject & object)
+{
+    MStatus stat;
+    MFnDagNode mFn(object);
+
+    // templated turned on?  return false
+    MPlug plug = mFn.findPlug("template", false, &stat);
+    if (stat == MS::kSuccess && plug.asBool())
+        return false;
+
+    // visibility or lodVisibility off?  return false
+    plug = mFn.findPlug("visibility", false, &stat);
+    if (stat == MS::kSuccess && !plug.asBool())
+    {
+        // the value is off. let's check if it has any in-connection,
+        // otherwise, it means it is not animated.
+        MPlugArray arrayIn;
+        plug.connectedTo(arrayIn, true, false, &stat);
+
+        if (stat == MS::kSuccess && arrayIn.length() == 0)
+        {
+            return false;
+        }
+    }
+
+    plug = mFn.findPlug("lodVisibility", false, &stat);
+    if (stat == MS::kSuccess && !plug.asBool())
+    {
+        MPlugArray arrayIn;
+        plug.connectedTo(arrayIn, true, false, &stat);
+
+        if (stat == MS::kSuccess && arrayIn.length() == 0)
+        {
+            return false;
+        }
+    }
+
+    // this shape is renderable
+    return true;
+}
+
+MString util::stripNamespaces(const MString & iNodeName, unsigned int iDepth)
+{
+    if (iDepth == 0)
+    {
+        return iNodeName;
+    }
+
+    MStringArray strArray;
+    if (iNodeName.split(':', strArray) == MS::kSuccess)
+    {
+        unsigned int len = strArray.length();
+
+        // we want to strip off more namespaces than what we have
+        // so we just return the last name
+        if (len == 0)
+        {
+            return iNodeName;
+        }
+        else if (len <= iDepth + 1)
+        {
+            return strArray[len-1];
+        }
+
+        MString name;
+        for (unsigned int i = iDepth; i < len - 1; ++i)
+        {
+            name += strArray[i];
+            name += ":";
+        }
+        name += strArray[len-1];
+        return name;
+    }
+
+    return iNodeName;
+}
+
+MString util::getHelpText()
+{
+    MString ret =
+"AbcExport [options]\n"
+"Options:\n"
+"-h / -help  Print this message.\n"
+"\n"
+"-prs / -preRollStartFrame double\n"
+"The frame to start scene evaluation at.  This is used to set the\n"
+"starting frame for time dependent translations and can be used to evaluate\n"
+"run-up that isn't actually translated.\n"
+"\n"
+"-duf / -dontSkipUnwrittenFrames\n"
+"When evaluating multiple translate jobs, the presence of this flag decides\n"
+"whether to evaluate frames between jobs when there is a gap in their frame\n"
+"ranges.\n"
+"\n"
+"-v / -verbose\n"
+"Prints the current frame that is being evaluated.\n"
+"\n"
+"-j / -jobArg string REQUIRED\n"
+"String which contains flags for writing data to a particular file.\n"
+"Multiple jobArgs can be specified.\n"
+"\n"
+"-jobArg flags:\n"
+"\n"
+"-a / -attr string\n"
+"A specific geometric attribute to write out.\n"
+"This flag may occur more than once.\n"
+"\n"
+"-df / -dataFormat string\n"
+"The data format to use to write the file.  Can be either HDF or Ogawa.\n"
+"The default is Ogawa.\n"
+"\n"
+"-atp / -attrPrefix string (default ABC_)\n"
+"Prefix filter for determining which geometric attributes to write out.\n"
+"This flag may occur more than once.\n"
+"\n"
+"-ef / -eulerFilter\n"
+"If this flag is present, apply Euler filter while sampling rotations.\n"
+"\n"
+"-f / -file string REQUIRED\n"
+"File location to write the Alembic data.\n"
+"\n"
+"-fr / -frameRange double double\n"
+"The frame range to write.\n"
+"Multiple occurrences of -frameRange are supported within a job. Each\n"
+"-frameRange defines a new frame range. -step or -frs will affect the\n"
+"current frame range only.\n"
+"\n"
+"-frs / -frameRelativeSample double\n"
+"frame relative sample that will be written out along the frame range.\n"
+"This flag may occur more than once.\n"
+"\n"
+"-nn / -noNormals\n"
+"If this flag is present normal data for Alembic poly meshes will not be\n"
+"written.\n"
+"\n"
+"-pr / -preRoll\n"
+"If this flag is present, this frame range will not be sampled.\n"
+"\n"
+"-ro / -renderableOnly\n"
+"If this flag is present non-renderable hierarchy (invisible, or templated)\n"
+"will not be written out.\n"
+"\n"
+"-rt / -root\n"
+"Maya dag path which will be parented to the root of the Alembic file.\n"
+"This flag may occur more than once.  If unspecified, it defaults to '|' which\n"
+"means the entire scene will be written out.\n"
+"\n"
+"-s / -step double (default 1.0)\n"
+"The time interval (expressed in frames) at which the frame range is sampled.\n"
+"Additional samples around each frame can be specified with -frs.\n"
+"\n"
+"-sl / -selection\n"
+"If this flag is present, write out all all selected nodes from the active\n"
+"selection list that are descendents of the roots specified with -root.\n"
+"\n"
+"-sn / -stripNamespaces (optional int)\n"
+"If this flag is present all namespaces will be stripped off of the node before\n"
+"being written to Alembic.  If an optional int is specified after the flag\n"
+"then that many namespaces will be stripped off of the node name. Be careful\n"
+"that the new stripped name does not collide with other sibling node names.\n\n"
+"Examples: \n"
+"taco:foo:bar would be written as just bar with -sn\n"
+"taco:foo:bar would be written as foo:bar with -sn 1\n"
+"\n"
+"-u / -userAttr string\n"
+"A specific user attribute to write out.  This flag may occur more than once.\n"
+"\n"
+"-uatp / -userAttrPrefix string\n"
+"Prefix filter for determining which user attributes to write out.\n"
+"This flag may occur more than once.\n"
+"\n"
+"-uv / -uvWrite\n"
+"If this flag is present, uv data for PolyMesh and SubD shapes will be written to\n"
+"the Alembic file.  Only the current uv map is used.\n"
+"\n"
+"-wcs / -writeColorSets\n"
+"Write all color sets on MFnMeshes as color 3 or color 4 indexed geometry \n"
+"parameters with face varying scope.\n"
+"\n"
+"-wfs / -writeFaceSets\n"
+"Write all Face sets on MFnMeshes.\n"
+"\n"
+"-wfg / -wholeFrameGeo\n"
+"If this flag is present data for geometry will only be written out on whole\n"
+"frames.\n"
+"\n"
+"-ws / -worldSpace\n"
+"If this flag is present, any root nodes will be stored in world space.\n"
+"\n"
+"-wv / -writeVisibility\n"
+"If this flag is present, visibility state will be stored in the Alembic\n"
+"file.  Otherwise everything written out is treated as visible.\n"
+"\n"
+"-wuvs / -writeUVSets\n"
+"Write all uv sets on MFnMeshes as vector 2 indexed geometry \n"
+"parameters with face varying scope.\n"
+"\n"
+"-mfc / -melPerFrameCallback string\n"
+"When each frame (and the static frame) is evaluated the string specified is\n"
+"evaluated as a Mel command. See below for special processing rules.\n"
+"\n"
+"-mpc / -melPostJobCallback string\n"
+"When the translation has finished the string specified is evaluated as a Mel\n"
+"command. See below for special processing rules.\n"
+"\n"
+"-pfc / -pythonPerFrameCallback string\n"
+"When each frame (and the static frame) is evaluated the string specified is\n"
+"evaluated as a python command. See below for special processing rules.\n"
+"\n"
+"-ppc / -pythonPostJobCallback string\n"
+"When the translation has finished the string specified is evaluated as a\n"
+"python command. See below for special processing rules.\n"
+"\n"
+"Special callback information:\n"
+"On the callbacks, special tokens are replaced with other data, these tokens\n"
+"and what they are replaced with are as follows:\n"
+"\n"
+"#FRAME# replaced with the frame number being evaluated.\n"
+"#FRAME# is ignored in the post callbacks.\n"
+"\n"
+"#BOUNDS# replaced with a string holding bounding box values in minX minY minZ\n"
+"maxX maxY maxZ space seperated order.\n"
+"\n"
+"#BOUNDSARRAY# replaced with the bounding box values as above, but in\n"
+"array form.\n"
+"In Mel: {minX, minY, minZ, maxX, maxY, maxZ}\n"
+"In Python: [minX, minY, minZ, maxX, maxY, maxZ]\n"
+"\n"
+"Examples:\n"
+"\n"
+"AbcExport -j \"-root |group|foo -root |test|path|bar -file /tmp/test.abc\"\n"
+"Writes out everything at foo and below and bar and below to /tmp/test.abc.\n"
+"foo and bar are siblings parented to the root of the Alembic scene.\n"
+"\n"
+"AbcExport -j \"-frameRange 1 5 -step 0.5 -root |group|foo -file /tmp/test.abc\"\n"
+"Writes out everything at foo and below to /tmp/test.abc sampling at frames:\n"
+"1 1.5 2 2.5 3 3.5 4 4.5 5\n"
+"\n"
+"AbcExport -j \"-fr 0 10 -frs -0.1 -frs 0.2 -step 5 -file /tmp/test.abc\"\n"
+"Writes out everything in the scene to /tmp/test.abc sampling at frames:\n"
+"-0.1 0.2 4.9 5.2 9.9 10.2\n"
+"\n"
+"Note: The difference between your highest and lowest frameRelativeSample can\n"
+"not be greater than your step size.\n"
+"\n"
+"AbcExport -j \"-step 0.25 -frs 0.3 -frs 0.60 -fr 1 5 -root foo -file test.abc\"\n"
+"\n"
+"Is illegal because the highest and lowest frameRelativeSamples are 0.3 frames\n"
+"apart.\n"
+"\n"
+"AbcExport -j \"-sl -root |group|foo -file /tmp/test.abc\"\n"
+"Writes out all selected nodes and it's ancestor nodes including up to foo.\n"
+"foo will be parented to the root of the Alembic scene.\n"
+"\n";
+
+    return ret;
+}

--- a/Maya/MayaUtility.h
+++ b/Maya/MayaUtility.h
@@ -1,0 +1,211 @@
+//-*****************************************************************************
+//
+// Copyright (c) 2009-2013,
+//  Sony Pictures Imageworks Inc. and
+//  Industrial Light & Magic, a division of Lucasfilm Entertainment Company Ltd.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+// *       Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// *       Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+// *       Neither the name of Sony Pictures Imageworks, nor
+// Industrial Light & Magic, nor the names of their contributors may be used
+// to endorse or promote products derived from this software without specific
+// prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//-*****************************************************************************
+
+#ifndef _AlembicExport_MayaUtility_h_
+#define _AlembicExport_MayaUtility_h_
+
+#include <Alembic/Abc/OArrayProperty.h>
+#include <Alembic/Abc/OScalarProperty.h>
+
+namespace util
+{
+
+struct cmpDag
+{
+    bool operator()( const MDagPath& lhs, const MDagPath& rhs ) const
+    {
+            std::string name1(lhs.fullPathName().asChar());
+            std::string name2(rhs.fullPathName().asChar());
+            return (name1.compare(name2) < 0);
+     }
+};
+typedef std::set< MDagPath, cmpDag > ShapeSet;
+
+inline MStatus isFloat(MString str, const MString & usage)
+{
+    MStatus status = MS::kSuccess;
+
+    if (!str.isFloat())
+    {
+        MGlobal::displayInfo(usage);
+        status = MS::kFailure;
+    }
+
+    return status;
+}
+
+inline MStatus isUnsigned(MString str, const MString & usage)
+{
+    MStatus status = MS::kSuccess;
+
+    if (!str.isUnsigned())
+    {
+        MGlobal::displayInfo(usage);
+        status = MS::kFailure;
+    }
+
+    return status;
+}
+
+// safely inverse a scale component
+inline double inverseScale(double scale)
+{
+    const double kScaleEpsilon = 1.0e-12;
+
+    if (scale < kScaleEpsilon && scale >= 0.0)
+        return 1.0 / kScaleEpsilon;
+    else if (scale > -kScaleEpsilon && scale < 0.0)
+        return 1.0 / -kScaleEpsilon;
+    else
+        return 1.0 / scale;
+}
+
+// seconds per frame
+double spf();
+
+bool isAncestorDescendentRelationship(const MDagPath & path1,
+    const MDagPath & path2);
+
+// returns 0 if static, 1 if sampled, and 2 if a curve
+int getSampledType(const MPlug& iPlug);
+
+// 0 dont write, 1 write static 0, 2 write anim 0, 3 write anim 1
+int getVisibilityType(const MPlug & iPlug);
+
+// determines what order we do the rotation in, returns false if iOrder is
+// kInvalid or kLast
+bool getRotOrder(MTransformationMatrix::RotationOrder iOrder,
+    unsigned int & oXAxis, unsigned int & oYAxis, unsigned int & oZAxis);
+
+// determine if a Maya Object is animated or not
+// copy from mayapit code (MayaPit.h .cpp)
+bool isAnimated(MObject & object, bool checkParent = false);
+
+// determine if a Maya Object is intermediate
+bool isIntermediate(const MObject & object);
+
+// returns true for visible and lod invisible and not templated objects
+bool isRenderable(const MObject & object);
+
+// strip iDepth namespaces from the node name, go from taco:foo:bar to bar
+// for iDepth > 1
+MString stripNamespaces(const MString & iNodeName, unsigned int iDepth);
+
+// returns the Help string for AbcExport
+MString getHelpText();
+
+} // namespace util
+
+struct PlugAndObjScalar
+{
+    MPlug plug;
+    MObject obj;
+    Alembic::Abc::OScalarProperty prop;
+};
+
+struct PlugAndObjArray
+{
+    MPlug plug;
+    MObject obj;
+    Alembic::Abc::OArrayProperty prop;
+};
+
+/*
+struct JobArgs
+{
+    JobArgs()
+    {
+        excludeInvisible = false;
+        filterEulerRotations = false;
+        noNormals = false;
+        stripNamespace = 0;
+        useSelectionList = false;
+        worldSpace = false;
+        writeVisibility = false;
+        writeUVs = false;
+        writeColorSets = false;
+        writeFaceSets = false;
+        writeUVSets = false;
+    }
+
+    bool excludeInvisible;
+    bool filterEulerRotations;
+    bool noNormals;
+    unsigned int stripNamespace;
+    bool useSelectionList;
+    bool worldSpace;
+    bool writeVisibility;
+    bool writeUVs;
+    bool writeColorSets;
+    bool writeFaceSets;
+    bool writeUVSets;
+    std::string melPerFrameCallback;
+    std::string melPostCallback;
+    std::string pythonPerFrameCallback;
+    std::string pythonPostCallback;
+
+    // to put into .arbGeomParam
+    std::vector< std::string > prefixFilters;
+    std::set< std::string > attribs;
+
+    // to put into .userProperties
+    std::vector< std::string > userPrefixFilters;
+    std::set< std::string > userAttribs;
+
+    util::ShapeSet dagPaths;
+};
+*/
+
+struct FrameRangeArgs
+{
+    FrameRangeArgs()
+    {
+        startTime = 0.0;
+        endTime = 0.0;
+        strideTime = 1.0;
+        preRoll = false;
+    }
+
+    double startTime;
+    double endTime;
+    double strideTime;
+
+    std::set< double > shutterSamples;
+
+    bool preRoll;
+};
+
+#endif  // _AlembicExport_MayaUtility_h_

--- a/Maya/UI/ExocortexAlembicAttach.ui
+++ b/Maya/UI/ExocortexAlembicAttach.ui
@@ -25,159 +25,137 @@
   <property name="windowTitle">
    <string>Alembic Import Settings</string>
   </property>
-  <widget class="QWidget" name="gridLayoutWidget">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>10</y>
-     <width>281</width>
-     <height>91</height>
-    </rect>
-   </property>
-   <layout class="QGridLayout" name="gridLayout">
-    <item row="0" column="0">
-     <widget class="QLabel" name="label">
-      <property name="text">
-       <string>Normals:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="1">
-     <widget class="QCheckBox" name="normals">
-      <property name="text">
-       <string/>
-      </property>
-      <property name="checked">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="0">
-     <widget class="QLabel" name="label_2">
-      <property name="text">
-       <string>UVs:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="1">
-     <widget class="QCheckBox" name="uvs">
-      <property name="text">
-       <string/>
-      </property>
-      <property name="checked">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="0">
-     <widget class="QLabel" name="label_3">
-      <property name="text">
-       <string>FaceSets:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="1">
-     <widget class="QCheckBox" name="facesets">
-      <property name="text">
-       <string/>
-      </property>
-      <property name="checked">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-
-    <item row="3" column="0">
-     <widget class="QLabel" name="label_3">
-      <property name="text">
-       <string>Override transforms:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="3" column="1">
-     <widget class="QCheckBox" name="otransform">
-      <property name="text">
-       <string/>
-      </property>
-      <property name="checked">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-
-    <item row="4" column="0">
-     <widget class="QLabel" name="label_3">
-      <property name="text">
-       <string>Override deforms:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="4" column="1">
-     <widget class="QCheckBox" name="odeform">
-      <property name="text">
-       <string/>
-      </property>
-      <property name="checked">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-
-   </layout>
-  </widget>
-
-  <widget class="QWidget" name="horizontalLayoutWidget">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>120</y>
-     <width>281</width>
-     <height>31</height>
-    </rect>
-   </property>
-
-   <layout class="QHBoxLayout" name="horizontalLayout">
-    <item>
-     <widget class="QPushButton" name="pushButton">
-      <property name="text">
-       <string>Import</string>
-      </property>
-      <property name="-c" stdset="0">
-       <string>&quot;exocortexChooseFile($dialog);&quot;</string>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QPushButton" name="pushButton_2">
-      <property name="text">
-       <string>Cancel</string>
-      </property>
-      <property name="-c" stdset="0">
-       <string>&quot;exocortexCloseDialog($dialog);&quot;</string>
-      </property>
-     </widget>
-    </item>
-   </layout>
-
-  </widget>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Normals:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QCheckBox" name="normals">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>UVs:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QCheckBox" name="uvs">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>FaceSets:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QCheckBox" name="facesets">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Override transforms:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QCheckBox" name="otransform">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Override deforms:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QCheckBox" name="odeform">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="pushButton">
+       <property name="text">
+        <string>Import</string>
+       </property>
+       <property name="-c" stdset="0">
+        <string>&quot;exocortexChooseFile($dialog);&quot;</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton_2">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+       <property name="-c" stdset="0">
+        <string>&quot;exocortexCloseDialog($dialog);&quot;</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>
 </ui>
-
-

--- a/Maya/UI/ExocortexAlembicExport.ui
+++ b/Maya/UI/ExocortexAlembicExport.ui
@@ -6,20 +6,20 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>350</width>
-    <height>350</height>
+    <width>355</width>
+    <height>390</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>350</width>
-    <height>350</height>
+    <width>355</width>
+    <height>390</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>354</width>
-    <height>350</height>
+    <width>355</width>
+    <height>390</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -28,20 +28,36 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
+     <item row="13" column="0">
+      <widget class="QLabel" name="label_2">
        <property name="text">
-        <string>In:</string>
+        <string>User Attributes:</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
       </widget>
      </item>
-     <item row="0" column="1">
-      <widget class="QLineEdit" name="inframe">
+     <item row="13" column="1">
+      <widget class="QLineEdit" name="userattrs"/>
+     </item>
+     <item row="9" column="1">
+      <widget class="QCheckBox" name="globalspace">
        <property name="text">
-        <string>1</string>
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <widget class="QCheckBox" name="shadingGroup">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
        </property>
       </widget>
      </item>
@@ -52,6 +68,63 @@
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="QCheckBox" name="dynamictopology">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="inframe">
+       <property name="text">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Uvs:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="1">
+      <widget class="QCheckBox" name="withouthierarchy">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QCheckBox" name="uvs">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="1">
+      <widget class="QCheckBox" name="transformcache">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
        </property>
       </widget>
      </item>
@@ -77,74 +150,10 @@
        </item>
       </widget>
      </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="label_5">
-       <property name="text">
-        <string>Uvs:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1">
-      <widget class="QCheckBox" name="uvs">
-       <property name="text">
-        <string/>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_6">
-       <property name="text">
-        <string>Out:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="outframe">
-       <property name="text">
-        <string>100</string>
-       </property>
-      </widget>
-     </item>
      <item row="2" column="1">
       <widget class="QLineEdit" name="stepframe">
        <property name="text">
         <string>1</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_7">
-       <property name="text">
-        <string>Frame-Steps:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QLineEdit" name="substepframe">
-       <property name="text">
-        <string>1</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="label_8">
-       <property name="text">
-        <string>Sub-Steps:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
       </widget>
      </item>
@@ -158,113 +167,10 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
-      <widget class="QCheckBox" name="facesets">
+     <item row="3" column="1">
+      <widget class="QLineEdit" name="substepframe">
        <property name="text">
-        <string/>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="label_9">
-       <property name="text">
-        <string>Use Initial Shading Group:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="1">
-      <widget class="QCheckBox" name="shadingGroup">
-       <property name="text">
-        <string/>
-       </property>
-       <property name="checked">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="0">
-      <widget class="QLabel" name="label_10">
-       <property name="text">
-        <string>Dynamic Topology:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="1">
-      <widget class="QCheckBox" name="dynamictopology">
-       <property name="text">
-        <string/>
-       </property>
-       <property name="checked">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="0">
-      <widget class="QLabel" name="label_11">
-       <property name="text">
-        <string>Global Space:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="1">
-      <widget class="QCheckBox" name="globalspace">
-       <property name="text">
-        <string/>
-       </property>
-       <property name="checked">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="0">
-      <widget class="QLabel" name="label_12">
-       <property name="text">
-        <string>Without Hierarchy:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="1">
-      <widget class="QCheckBox" name="withouthierarchy">
-       <property name="text">
-        <string/>
-       </property>
-       <property name="checked">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="11" column="0">
-      <widget class="QLabel" name="label_12">
-       <property name="text">
-        <string>Transform Cache:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="11" column="1">
-      <widget class="QCheckBox" name="transformcache">
-       <property name="text">
-        <string/>
-       </property>
-       <property name="checked">
-        <bool>false</bool>
+        <string>1</string>
        </property>
       </widget>
      </item>
@@ -272,6 +178,16 @@
       <widget class="QLabel" name="label_db">
        <property name="text">
         <string>Database:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>Out:</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -294,6 +210,116 @@
         </property>
        </item>
       </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QCheckBox" name="facesets">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>In:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="label_10">
+       <property name="text">
+        <string>Dynamic Topology:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="0">
+      <widget class="QLabel" name="label_12">
+       <property name="text">
+        <string>Transform Cache:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="outframe">
+       <property name="text">
+        <string>100</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_7">
+       <property name="text">
+        <string>Frame-Steps:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_8">
+       <property name="text">
+        <string>Sub-Steps:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="0">
+      <widget class="QLabel" name="label_9">
+       <property name="text">
+        <string>Use Initial Shading Group:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="0">
+      <widget class="QLabel" name="label_12">
+       <property name="text">
+        <string>Without Hierarchy:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0">
+      <widget class="QLabel" name="label_11">
+       <property name="text">
+        <string>Global Space:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="14" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>User Attribute Prefixes:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="14" column="1">
+      <widget class="QLineEdit" name="userattrprefixes"/>
      </item>
     </layout>
    </item>

--- a/Maya/UI/ExocortexAlembicExport.ui
+++ b/Maya/UI/ExocortexAlembicExport.ui
@@ -18,355 +18,311 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>350</width>
+    <width>354</width>
     <height>350</height>
    </size>
   </property>
   <property name="windowTitle">
    <string>Alembic Export Settings</string>
   </property>
-  <widget class="QWidget" name="gridLayoutWidget">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>10</y>
-     <width>331</width>
-     <height>320</height>
-    </rect>
-   </property>
-   <layout class="QGridLayout" name="gridLayout">
-
-    <!-- In -->
-    <item row="0" column="0">
-     <widget class="QLabel" name="label">
-      <property name="text">
-       <string>In:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="1">
-     <widget class="QLineEdit" name="inframe">
-      <property name="text">
-       <string>1</string>
-      </property>
-     </widget>
-    </item>
-
-    <!-- Topology -->
-    <item row="4" column="0">
-     <widget class="QLabel" name="label_4">
-      <property name="text">
-       <string>Topology:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="4" column="1">
-     <widget class="QComboBox" name="topology">
-      <property name="currentIndex">
-       <number>2</number>
-      </property>
-      <item>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
        <property name="text">
-        <string>Point Cache (No surface)</string>
+        <string>In:</string>
        </property>
-      </item>
-      <item>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="inframe">
        <property name="text">
-        <string>Just Surface (No normals)</string>
+        <string>1</string>
        </property>
-      </item>
-      <item>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_4">
        <property name="text">
-        <string>Surface + Normals (For Interchange)</string>
+        <string>Topology:</string>
        </property>
-      </item>
-     </widget>
-    </item>
-
-    <!-- UVs -->
-    <item row="5" column="0">
-     <widget class="QLabel" name="label_5">
-      <property name="text">
-       <string>Uvs:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="5" column="1">
-     <widget class="QCheckBox" name="uvs">
-      <property name="text">
-       <string/>
-      </property>
-      <property name="checked">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-
-    <!-- Out -->
-    <item row="1" column="0">
-     <widget class="QLabel" name="label_6">
-      <property name="text">
-       <string>Out:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="1">
-     <widget class="QLineEdit" name="outframe">
-      <property name="text">
-       <string>100</string>
-      </property>
-     </widget>
-    </item>
-
-    <!-- Frame step -->
-    <item row="2" column="1">
-     <widget class="QLineEdit" name="stepframe">
-      <property name="text">
-       <string>1</string>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="0">
-     <widget class="QLabel" name="label_7">
-      <property name="text">
-       <string>Frame-Steps:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-
-    <!-- Sub step -->
-    <item row="3" column="1">
-     <widget class="QLineEdit" name="substepframe">
-      <property name="text">
-       <string>1</string>
-      </property>
-     </widget>
-    </item>
-    <item row="3" column="0">
-     <widget class="QLabel" name="label_8">
-      <property name="text">
-       <string>Sub-Steps:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-
-    <!-- Faceset -->
-    <item row="6" column="0">
-     <widget class="QLabel" name="label_9">
-      <property name="text">
-       <string>FaceSets:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="6" column="1">
-     <widget class="QCheckBox" name="facesets">
-      <property name="text">
-       <string/>
-      </property>
-      <property name="checked">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-
-    <!-- Use init. shading group -->
-    <item row="7" column="0">
-     <widget class="QLabel" name="label_9">
-      <property name="text">
-       <string>Use Initial Shading Group:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="7" column="1">
-     <widget class="QCheckBox" name="shadingGroup">
-      <property name="text">
-       <string/>
-      </property>
-      <property name="checked">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-
-    <!-- Dynamic Topology -->
-    <item row="8" column="0">
-     <widget class="QLabel" name="label_10">
-      <property name="text">
-       <string>Dynamic Topology:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="8" column="1">
-     <widget class="QCheckBox" name="dynamictopology">
-      <property name="text">
-       <string/>
-      </property>
-      <property name="checked">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-
-    <!-- Global Space -->
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QComboBox" name="topology">
+       <property name="currentIndex">
+        <number>2</number>
+       </property>
+       <item>
+        <property name="text">
+         <string>Point Cache (No surface)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Just Surface (No normals)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Surface + Normals (For Interchange)</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Uvs:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QCheckBox" name="uvs">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>Out:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="outframe">
+       <property name="text">
+        <string>100</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="stepframe">
+       <property name="text">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_7">
+       <property name="text">
+        <string>Frame-Steps:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QLineEdit" name="substepframe">
+       <property name="text">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_8">
+       <property name="text">
+        <string>Sub-Steps:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="label_9">
+       <property name="text">
+        <string>FaceSets:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QCheckBox" name="facesets">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="0">
+      <widget class="QLabel" name="label_9">
+       <property name="text">
+        <string>Use Initial Shading Group:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <widget class="QCheckBox" name="shadingGroup">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="label_10">
+       <property name="text">
+        <string>Dynamic Topology:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="QCheckBox" name="dynamictopology">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
      <item row="9" column="0">
-       <widget class="QLabel" name="label_11">
-         <property name="text">
-           <string>Global Space:</string>
-         </property>
-         <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-       </widget>
+      <widget class="QLabel" name="label_11">
+       <property name="text">
+        <string>Global Space:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
      </item>
      <item row="9" column="1">
-       <widget class="QCheckBox" name="globalspace">
-         <property name="text">
-           <string/>
-         </property>
-         <property name="checked">
-           <bool>false</bool>
-         </property>
-       </widget>
+      <widget class="QCheckBox" name="globalspace">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
      </item>
-
-    <!-- No Hierarchy -->
      <item row="10" column="0">
-       <widget class="QLabel" name="label_12">
-         <property name="text">
-           <string>Without Hierarchy:</string>
-         </property>
-         <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-       </widget>
+      <widget class="QLabel" name="label_12">
+       <property name="text">
+        <string>Without Hierarchy:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
      </item>
      <item row="10" column="1">
-       <widget class="QCheckBox" name="withouthierarchy">
-         <property name="text">
-           <string/>
-         </property>
-         <property name="checked">
-           <bool>false</bool>
-         </property>
-       </widget>
+      <widget class="QCheckBox" name="withouthierarchy">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
      </item>
-
-    <!-- Xform cache -->
      <item row="11" column="0">
-       <widget class="QLabel" name="label_12">
-         <property name="text">
-           <string>Transform Cache:</string>
-         </property>
-         <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-       </widget>
+      <widget class="QLabel" name="label_12">
+       <property name="text">
+        <string>Transform Cache:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
      </item>
      <item row="11" column="1">
-       <widget class="QCheckBox" name="transformcache">
-         <property name="text">
-           <string/>
-         </property>
-         <property name="checked">
-           <bool>false</bool>
-         </property>
-       </widget>
+      <widget class="QCheckBox" name="transformcache">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
      </item>
-
-    <!-- Database -->
-    <item row="12" column="0">
-     <widget class="QLabel" name="label_db">
-      <property name="text">
-       <string>Database:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="12" column="1">
-     <widget class="QComboBox" name="database">
-      <property name="currentIndex">
-       <number>0</number>
-      </property>
-      <item>
+     <item row="12" column="0">
+      <widget class="QLabel" name="label_db">
        <property name="text">
-        <string>HDF5</string>
+        <string>Database:</string>
        </property>
-      </item>
-      <item>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="12" column="1">
+      <widget class="QComboBox" name="database">
+       <property name="currentIndex">
+        <number>0</number>
+       </property>
+       <item>
+        <property name="text">
+         <string>HDF5</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Ogawa</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="pushButton">
        <property name="text">
-        <string>Ogawa</string>
+        <string>Export</string>
        </property>
-      </item>
-     </widget>
-    </item>
-
-   </layout>
-  </widget>
-
-  <widget class="QWidget" name="horizontalLayoutWidget">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>320</y>
-     <width>331</width>
-     <height>31</height>
-    </rect>
-   </property>
-   <layout class="QHBoxLayout" name="horizontalLayout">
-    <item>
-     <widget class="QPushButton" name="pushButton">
-      <property name="text">
-       <string>Export</string>
-      </property>
-      <property name="-c" stdset="0">
-       <string>&quot;exocortexChooseFile($dialog);&quot;</string>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QPushButton" name="pushButton_2">
-      <property name="text">
-       <string>Cancel</string>
-      </property>
-      <property name="-c" stdset="0">
-       <string>&quot;exocortexCloseDialog($dialog);&quot;</string>
-      </property>
-     </widget>
-    </item>
-   </layout>
-  </widget>
+       <property name="-c" stdset="0">
+        <string>&quot;exocortexChooseFile($dialog);&quot;</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton_2">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+       <property name="-c" stdset="0">
+        <string>&quot;exocortexCloseDialog($dialog);&quot;</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>
 </ui>
-
-

--- a/Maya/UI/ExocortexAlembicImport.ui
+++ b/Maya/UI/ExocortexAlembicImport.ui
@@ -7,211 +7,182 @@
     <x>0</x>
     <y>0</y>
     <width>300</width>
-    <height>160</height>
+    <height>170</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>300</width>
-    <height>160</height>
+    <height>170</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
     <width>300</width>
-    <height>160</height>
+    <height>170</height>
    </size>
   </property>
   <property name="windowTitle">
    <string>Alembic Import Settings</string>
   </property>
-  <widget class="QWidget" name="gridLayoutWidget">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>10</y>
-     <width>281</width>
-     <height>91</height>
-    </rect>
-   </property>
-   <layout class="QGridLayout" name="gridLayout">
-
-    <!-- Support for Normals! -->
-    <item row="0" column="0">
-     <widget class="QLabel" name="label">
-      <property name="text">
-       <string>Normals:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="1">
-     <widget class="QCheckBox" name="normals">
-      <property name="text">
-       <string/>
-      </property>
-      <property name="checked">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-
-    <!-- Support for UVs! -->
-    <item row="1" column="0">
-     <widget class="QLabel" name="label_2">
-      <property name="text">
-       <string>UVs:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="1">
-     <widget class="QCheckBox" name="uvs">
-      <property name="text">
-       <string/>
-      </property>
-      <property name="checked">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-
-    <!-- Support for Face Sets! -->
-    <item row="2" column="0">
-     <widget class="QLabel" name="label_3">
-      <property name="text">
-       <string>FaceSets:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="1">
-     <widget class="QCheckBox" name="facesets">
-      <property name="text">
-       <string/>
-      </property>
-      <property name="checked">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-
-    <!-- Support for Visibility! -->
-    <item row="3" column="0">
-     <widget class="QLabel" name="label_4">
-      <property name="text">
-       <string>Visibility:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="3" column="1">
-     <widget class="QComboBox" name="visibility">
-      <property name="currentIndex">
-       <number>0</number>
-      </property>
-      <item>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
        <property name="text">
-        <string>Just Import Values</string>
+        <string>Normals:</string>
        </property>
-      </item>
-      <item>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QCheckBox" name="normals">
        <property name="text">
-        <string>Connected Nodes</string>
+        <string/>
        </property>
-      </item>
-     </widget>
-    </item>
-
-    <!-- Support for Multi files! -->
-    <item row="4" column="0">
-     <widget class="QLabel" name="multifile_lbl">
-      <property name="text">
-       <string>Multi File:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="4" column="1">
-     <widget class="QCheckBox" name="multifile">
-      <property name="text">
-       <string/>
-      </property>
-      <property name="checked">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-
-    <!-- Fit Time Range -->
-    <item row="5" column="0">
-     <widget class="QLabel" name="fitTR_lbl">
-      <property name="text">
-       <string>Fit Time Range:</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-     </widget>
-    </item>
-    <item row="5" column="1">
-     <widget class="QCheckBox" name="fitTR">
-      <property name="text">
-       <string/>
-      </property>
-      <property name="checked">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-
-   </layout>
-  </widget>
-  <widget class="QWidget" name="horizontalLayoutWidget">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>120</y>
-     <width>281</width>
-     <height>31</height>
-    </rect>
-   </property>
-   <layout class="QHBoxLayout" name="horizontalLayout">
-    <item>
-     <widget class="QPushButton" name="pushButton">
-      <property name="text">
-       <string>Import</string>
-      </property>
-      <property name="-c" stdset="0">
-       <string>&quot;exocortexChooseFile($dialog);&quot;</string>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QPushButton" name="pushButton_2">
-      <property name="text">
-       <string>Cancel</string>
-      </property>
-      <property name="-c" stdset="0">
-       <string>&quot;exocortexCloseDialog($dialog);&quot;</string>
-      </property>
-     </widget>
-    </item>
-   </layout>
-  </widget>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>UVs:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QCheckBox" name="uvs">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>FaceSets:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QCheckBox" name="facesets">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Visibility:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QComboBox" name="visibility">
+       <property name="currentIndex">
+        <number>0</number>
+       </property>
+       <item>
+        <property name="text">
+         <string>Just Import Values</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Connected Nodes</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="multifile_lbl">
+       <property name="text">
+        <string>Multi File:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QCheckBox" name="multifile">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="fitTR_lbl">
+       <property name="text">
+        <string>Fit Time Range:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QCheckBox" name="fitTR">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="pushButton">
+       <property name="text">
+        <string>Import</string>
+       </property>
+       <property name="-c" stdset="0">
+        <string>&quot;exocortexChooseFile($dialog);&quot;</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton_2">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+       <property name="-c" stdset="0">
+        <string>&quot;exocortexCloseDialog($dialog);&quot;</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>
 </ui>
-
-

--- a/Maya/Utility.h
+++ b/Maya/Utility.h
@@ -17,6 +17,9 @@ MObject getRefFromIdentifier(std::string in_Identifier);
 bool isRefAnimated(const MObject& in_Ref);
 bool returnIsRefAnimated(const MObject& in_Ref, bool animated);
 void clearIsRefAnimatedCache();
+MStatus getPlugArrayFromAttrList(const MString &list,
+    const MObject &obj,
+    MPlugArray &plugs);
 
 // remapping imported names
 void nameMapAdd(MString identifier, MString name);

--- a/Maya/sceneGraph.cpp
+++ b/Maya/sceneGraph.cpp
@@ -1,9 +1,11 @@
 #include "stdafx.h"
 
+#include "AttributesReading.h"
 #include "sceneGraph.h"
 
 #include "CommonLog.h"
 
+#include <maya/MDGModifier.h>
 #include <maya/MFnDagNode.h>
 #include <maya/MItDag.h>
 
@@ -17,6 +19,17 @@ static void __file_and_time_control_kill(const MString &var)
 {
   MGlobal::executePythonCommand(
       var + " = None\n");  // deallocate this variable in Python!
+}
+
+MObject findMObjectByName(const std::string &obj)
+{
+  MSelectionList selList;
+  selList.add(obj.c_str());
+
+  MObject result;
+  selList.getDependNode(0, result);
+
+  return result;
 }
 
 AlembicFileAndTimeControl::~AlembicFileAndTimeControl(void)
@@ -61,7 +74,8 @@ bool SceneNodeMaya::replaceSimilarData(const char *functionName,
              this->connectTo.length() == 0 ? this->dccIdentifier.c_str() : this->connectTo,
              fileNode->dccIdentifier.c_str(), fileAndTime->variable(),
              PythonBool(fileNode->pObjCache->isConstant));
-  MStatus result = MGlobal::executePythonCommand(cmd);
+  MString results;
+  MStatus result = MGlobal::executePythonCommand(cmd, results);
   if (result.error()) {
     ESS_LOG_WARNING("Attached failed for " << functionName << ", reason: "
                                            << result.errorString().asChar());
@@ -102,24 +116,134 @@ bool SceneNodeMaya::replaceData(SceneNodeAlembicPtr fileNode,
   return false;
 }
 
+bool connectPropsToShape(MFnDependencyNode &depNode,
+    MFnDependencyNode &readerDepNode)
+{
+  MStatus status;
+  MPlug geomParamsPlug = readerDepNode.findPlug("ExocortexAlembic_GeomParams",
+      &status);
+  MPlug userAttrsPlug = readerDepNode.findPlug("ExocortexAlembic_UserAttributes",
+      &status);
+  if (status != MStatus::kSuccess) {
+    return false;
+  }
+
+  MString geomProp;
+  status = geomParamsPlug.getValue(geomProp);
+  MString userProp;
+  status = userAttrsPlug.getValue(userProp);
+  if (status != MStatus::kSuccess) {
+    return false;
+  }
+
+  MStringArray geomProps;
+  geomProp.split(';', geomProps);
+  MStringArray userProps;
+  userProp.split(';', userProps);
+
+  MDGModifier mod;
+  for (unsigned int i = 0; i < geomProps.length(); i++) {
+    MStatus propStatus;
+    MPlug readerPlug = readerDepNode.findPlug(geomProps[i], &propStatus);
+    MPlug shapePlug = depNode.findPlug(geomProps[i], &propStatus);
+    if (propStatus == MStatus::kSuccess) {
+      mod.connect(readerPlug, shapePlug);
+    }
+  }
+
+  for (unsigned int i = 0; i < userProps.length(); i++) {
+    MStatus propStatus;
+    MPlug readerPlug = readerDepNode.findPlug(userProps[i], &propStatus);
+    MPlug shapePlug = depNode.findPlug(userProps[i], &propStatus);
+    if (propStatus == MStatus::kSuccess) {
+      mod.connect(readerPlug, shapePlug);
+    }
+  }
+
+  status = mod.doIt();
+
+  return (status == MStatus::kSuccess);
+}
+
+template<typename OBJECT_TYPE, typename SCHEMA_TYPE>
+bool addAndConnectPropsToShape(SceneNodeAppPtr &newAppNode)
+{
+  MStatus status;
+  MObject node = findMObjectByName(newAppNode->dccIdentifier);
+  MObject readerNode = findMObjectByName(newAppNode->dccReaderIdentifier);
+
+  MFnDependencyNode depNode(node, &status);
+  MFnDependencyNode readerDepNode(readerNode, &status);
+
+  MPlug fileNamePlug = readerDepNode.findPlug("fileName", &status);
+  MPlug identifierPlug = readerDepNode.findPlug("identifier", &status);
+  MPlug geomParamsPlug = readerDepNode.findPlug("ExocortexAlembic_GeomParams",
+      &status);
+  MPlug userAttrsPlug = readerDepNode.findPlug("ExocortexAlembic_UserAttributes",
+      &status);
+
+  MString fileName;
+  status = fileNamePlug.getValue(fileName);
+  MString identifier;
+  status = identifierPlug.getValue(identifier);
+
+  if (status != MStatus::kSuccess) {
+    return false;
+  }
+
+  // Don't show these warnings; let the reader node display them
+  Alembic::Abc::IObject iObj = getObjectFromArchive(fileName, identifier);
+  if (!iObj.valid()) {
+    return false;
+  }
+
+  OBJECT_TYPE obj = OBJECT_TYPE(iObj, Alembic::Abc::kWrapExisting);
+  if (!obj.valid()) {
+    return false;
+  }
+
+  SCHEMA_TYPE schema = obj.getSchema();
+
+  if (!schema.valid()) {
+    return false;
+  }
+
+  Alembic::Abc::ICompoundProperty arbProp = schema.getArbGeomParams();
+  Alembic::Abc::ICompoundProperty userProp = schema.getUserProperties();
+
+  addProps(arbProp, node, false, true);
+  addProps(userProp, node, false, true);
+  std::string arbPropStr = addProps(arbProp, readerNode, false, false);
+  std::string userPropStr = addProps(userProp, readerNode, false, false);
+
+  geomParamsPlug.setValue(arbPropStr.c_str());
+  userAttrsPlug.setValue(userPropStr.c_str());
+
+  return connectPropsToShape(depNode, readerDepNode);
+}
+
 bool SceneNodeMaya::executeAddChild(const MString &cmd,
                                     SceneNodeAppPtr &newAppNode)
 {
-  MString result;
-  MGlobal::executePythonCommand(cmd, result);
-  if (result.length() == 0) {
+  std::string cmdstr(cmd.asChar());
+  MStringArray results;
+  MGlobal::executePythonCommand(cmdstr.c_str(), results);
+  if (results.length() == 0 || results[0].length() == 0) {
     return false;
   }
-  else if (result.asChar()[0] == '?') {
+  else if (results.length() != 2 || results[1].length() == 0) {
 #ifdef _DEBUG
-    MGlobal::displayError(result);
+    std::ostringstream resultsStream;
+    resultsStream << results;
+    MGlobal::displayError(resultsStream.str().c_str());
     MGlobal::displayError(cmd);
 #endif
     return false;
   }
 
-  newAppNode->dccIdentifier = result.asChar();
+  newAppNode->dccIdentifier = results[0].asChar();
   newAppNode->name = newAppNode->dccIdentifier;
+  newAppNode->dccReaderIdentifier = results[1].asChar();
   return true;
 }
 
@@ -160,9 +284,15 @@ bool SceneNodeMaya::addXformChild(SceneNodeAlembicPtr fileNode,
 
   MString cmd;
   cmd.format(format, fileNode->name.c_str(), fileNode->dccIdentifier.c_str(),
-             fileAndTime->variable(), parent,
-             PythonBool(fileNode->pObjCache->isConstant));
-  return executeAddChild(cmd, newAppNode);
+      fileAndTime->variable(), parent,
+      PythonBool(fileNode->pObjCache->isConstant));
+  if (!executeAddChild(cmd, newAppNode)) {
+    return false;
+  }
+
+  return addAndConnectPropsToShape<Alembic::AbcGeom::IXform,
+         Alembic::AbcGeom::IXformSchema>(
+             newAppNode);
 }
 
 bool SceneNodeMaya::addPolyMeshChild(SceneNodeAlembicPtr fileNode,
@@ -178,7 +308,14 @@ bool SceneNodeMaya::addPolyMeshChild(SceneNodeAlembicPtr fileNode,
              fileAndTime->variable(), dccIdentifier.c_str(),
              PythonBool(fileNode->pObjCache->isConstant),
              PythonBool(fileNode->pObjCache->isMeshTopoDynamic));
-  return executeAddChild(cmd, newAppNode);
+
+  if (!executeAddChild(cmd, newAppNode)) {
+    return false;
+  }
+
+  return addAndConnectPropsToShape<Alembic::AbcGeom::IPolyMesh,
+         Alembic::AbcGeom::IPolyMeshSchema>(
+             newAppNode);
 }
 
 bool SceneNodeMaya::addCurveChild(SceneNodeAlembicPtr fileNode,
@@ -201,7 +338,13 @@ bool SceneNodeMaya::addCurveChild(SceneNodeAlembicPtr fileNode,
   cmd.format(format, fileNode->name.c_str(), fileNode->dccIdentifier.c_str(),
              fileAndTime->variable(), dccIdentifier.c_str(),
              PythonBool(fileNode->pObjCache->isConstant), strNb);
-  return executeAddChild(cmd, newAppNode);
+  if (!executeAddChild(cmd, newAppNode)) {
+    return false;
+  }
+
+  return addAndConnectPropsToShape<Alembic::AbcGeom::ICurves,
+         Alembic::AbcGeom::ICurvesSchema>(
+             newAppNode);
 }
 
 bool SceneNodeMaya::addChild(SceneNodeAlembicPtr fileNode,
@@ -216,7 +359,12 @@ bool SceneNodeMaya::addChild(SceneNodeAlembicPtr fileNode,
     case ITRANSFORM:
       return addXformChild(fileNode, newAppNode);
     case CAMERA:
-      return addSimilarChild("Camera", fileNode, newAppNode);
+      if (!addSimilarChild("Camera", fileNode, newAppNode)) {
+        return false;
+      }
+      return addAndConnectPropsToShape<Alembic::AbcGeom::ICamera,
+             Alembic::AbcGeom::ICameraSchema>(
+                 newAppNode);
     case POLYMESH:
     case SUBD:
       return addPolyMeshChild(fileNode, newAppNode);
@@ -224,7 +372,12 @@ bool SceneNodeMaya::addChild(SceneNodeAlembicPtr fileNode,
     case HAIR:
       return addCurveChild(fileNode, newAppNode);
     case PARTICLES:
-      return addSimilarChild("Points", fileNode, newAppNode);
+      if (!addSimilarChild("Points", fileNode, newAppNode)) {
+        return false;
+      }
+      return addAndConnectPropsToShape<Alembic::AbcGeom::IPoints,
+             Alembic::AbcGeom::IPointsSchema>(
+                 newAppNode);
     // case SURFACE:	// handle as default for now
     // break;
     // case LIGHT:	// handle as default for now

--- a/Maya/sceneGraph.h
+++ b/Maya/sceneGraph.h
@@ -28,9 +28,126 @@ class SceneNodeMaya : public SceneNodeApp {
   AlembicFileAndTimeControlPtr fileAndTime;
   bool useMultiFile;
 
+  bool removeProps(const MString &dccReaderIdentifier);
+  bool connectProps(MFnDependencyNode &depNode,
+      MFnDependencyNode &readerDepNode);
+
+  template<typename OBJECT_TYPE, typename SCHEMA_TYPE>
+    bool addAndConnectProps(const MString &dccIdentifier,
+        const MString &dccReaderIdentifier,
+        bool addPropsToShape)
+    {
+      MStatus status;
+      MObject node = findMObjectByName(dccIdentifier);
+      MObject readerNode = findMObjectByName(dccReaderIdentifier);
+
+      MFnDependencyNode depNode(node, &status);
+      MFnDependencyNode readerDepNode(readerNode, &status);
+
+      MPlug fileNamePlug = readerDepNode.findPlug("fileName", &status);
+      MPlug identifierPlug = readerDepNode.findPlug("identifier", &status);
+      MPlug geomParamsPlug = readerDepNode.findPlug("ExocortexAlembic_GeomParams",
+          &status);
+      MPlug userAttrsPlug = readerDepNode.findPlug("ExocortexAlembic_UserAttributes",
+          &status);
+
+      MString fileName;
+      status = fileNamePlug.getValue(fileName);
+      MString identifier;
+      status = identifierPlug.getValue(identifier);
+
+      if (status != MStatus::kSuccess) {
+        return false;
+      }
+
+      // Don't show these warnings; let the reader node display them
+      Alembic::Abc::IObject iObj = getObjectFromArchive(fileName, identifier);
+      if (!iObj.valid()) {
+        return false;
+      }
+
+      OBJECT_TYPE obj = OBJECT_TYPE(iObj, Alembic::Abc::kWrapExisting);
+      if (!obj.valid()) {
+        return false;
+      }
+
+      SCHEMA_TYPE schema = obj.getSchema();
+
+      if (!schema.valid()) {
+        return false;
+      }
+
+      Alembic::Abc::ICompoundProperty arbProp = schema.getArbGeomParams();
+      Alembic::Abc::ICompoundProperty userProp = schema.getUserProperties();
+
+      if (addPropsToShape) {
+        addProps(arbProp, node, false, true);
+        addProps(userProp, node, false, true);
+      }
+      std::string arbPropStr = addProps(arbProp, readerNode, false, false);
+      std::string userPropStr = addProps(userProp, readerNode, false, false);
+
+      geomParamsPlug.setValue(arbPropStr.c_str());
+      userAttrsPlug.setValue(userPropStr.c_str());
+
+      return connectProps(depNode, readerDepNode);
+    }
+
+  template<typename OBJECT_TYPE, typename SCHEMA_TYPE>
+    inline bool addAndConnectProps(SceneNodeAppPtr &newAppNode)
+    {
+      return addAndConnectProps<OBJECT_TYPE, SCHEMA_TYPE>(
+          newAppNode->dccIdentifier.c_str(),
+          newAppNode->dccReaderIdentifier.c_str(),
+          true
+          );
+    }
+
+
   // --- replace data
-  bool replaceSimilarData(const char* functionName,
-                          SceneNodeAlembicPtr fileNode);
+  template<typename OBJECT_TYPE, typename SCHEMA_TYPE>
+    bool replaceSimilarData(const char *functionName,
+        SceneNodeAlembicPtr fileNode)
+    {
+      static const MString format(
+          "ExoAlembic._attach.attach^1s(r\"^2s\", r\"^3s\", ^4s, ^5s)");
+
+      ESS_PROFILE_SCOPE("SceneNodeMaya::replaceSimilarData");
+
+      const MString connectTo = this->connectTo.length() == 0
+        ? this->dccIdentifier.c_str()
+        : this->connectTo;
+
+      MString cmd;
+      cmd.format(format, functionName, connectTo,
+          fileNode->dccIdentifier.c_str(), fileAndTime->variable(),
+          PythonBool(fileNode->pObjCache->isConstant));
+      MStringArray results;
+      MStatus result = MGlobal::executePythonCommand(cmd, results);
+      if (result.error() && results.length() != 2) {
+        ESS_LOG_WARNING("Attached failed for " << functionName << ", reason: "
+            << result.errorString().asChar());
+        return false;
+      }
+      if (results.length() == 2) {
+        ESS_LOG_WARNING("Attached failed for " << functionName << ", reason: "
+            << results[1].asChar());
+        return false;
+      }
+
+      if (!removeProps(results[0])) {
+        return false;
+      }
+
+      if (!addAndConnectProps<OBJECT_TYPE, SCHEMA_TYPE>(
+            connectTo, results[0], false)) {
+        return false;
+      }
+
+      fileNode->setAttached(true);
+      return true;
+    }
+
 
   // --- add child
   bool executeAddChild(const MString& cmd, SceneNodeAppPtr& newAppNode);

--- a/Maya/utility.cpp
+++ b/Maya/utility.cpp
@@ -177,6 +177,29 @@ bool returnIsRefAnimated(const MObject& in_Ref, bool animated)
 }
 
 void clearIsRefAnimatedCache() { gIsRefAnimatedMap.clear(); }
+
+MStatus getPlugArrayFromAttrList(const MString &list,
+    const MObject &obj,
+    MPlugArray &plugs)
+{
+  MStatus status;
+  MFnDependencyNode depNode(obj, &status);
+
+  MStringArray attrs;
+  status = list.split(';', attrs);
+
+  plugs.clear();
+  for (unsigned int i = 0; i < attrs.length(); i++) {
+    MStatus plugStatus;
+    MPlug plug = depNode.findPlug(attrs[i], &plugStatus);
+    if (!plugStatus.error()) {
+      status = plugs.append(plug);
+    }
+  }
+
+  return status;
+}
+
 std::map<std::string, std::string> gNameMap;
 void nameMapAdd(MString identifier, MString name)
 {

--- a/Shared/CommonUtils/CommonSceneGraph.h
+++ b/Shared/CommonUtils/CommonSceneGraph.h
@@ -62,6 +62,7 @@ public:
    nodeTypeE type;
    std::string name;
    std::string dccIdentifier;
+   std::string dccReaderIdentifier;
    bool dccSelected;
    bool selected;
 


### PR DESCRIPTION
This pull request implements attribute caching via the .arbGeomParams and .userAttributes fields of Alembic files.

During imports, all the attributes in the alembic are added to both the shape node and the reader node, and connections are made for these attributes from the reader node to the shape node. It also fills the new `ExocortexAlembic_GeomParams` and `ExocortexAlembic_UserAttributes` fields on reader nodes. These fields are required by the attachment progress. During attachments, the attachment process deletes all of the attributes on the reader node using `ExocortexAlembic_GeomParams` and `ExocortexAlembic_UserAttributes`, does the normal attaching, and then readds and connects the attributes on the reader node.

This is a requirement because of the way that Maya nodes work. Therefore although you can still change the path to the alembic file on `ExocortexAlembicFile` nodes, new attributes will not be added and old ones won't be removed.

Attributes can be cached using any of the following fields in export jobs:
```attrs=RenderAttr1,RenderAttr2,...
attrprefixes=CacheThis_,ExamplePrefix,...
userattrs=Attr1,Attr2,...
userattrprefixes=CacheMe_,CacheMeAlso_,...
```

Attributes specified in `attrs` are cached into .arbGeomParams in the Alembic. Any attribute that has a name that begins with a prefix in `attrprefixes` is also cached into .arbGeomParams. (Similarly for `userattrs` and `userattrprefixes` with .userAttributes in the alembic).

Attributes should not begin with a '.' as these are use internally by Crate already for some node types (eg particles and curves). This breaks compatibility with Maya versions <= 2013. It also doesn't work well with Parallel evaluation with Maya 2016 (not that all of the default Maya nodes do...). Support for attributes on FaceSets is not implemented.

For now Crate no longer doesn't attach the reader and shape nodes together when the alembic schema for the shape node is constant. This is to cater for the case when transform and other standard attributes don't change, but the geom params and user attributes do. To fix this it needs a change in `Shared/CommonUtils/CommonSceneGraph.cpp` where `isConstant` is set.

I've also implemented super simple fields in the Export UI for specifying user attributes and user attribute prefixes. These are just simple line edits that pass whatever is in the box straight to the `userattrs` and `userattrprefixes` fields, so they expect a comma separated list of attribute names and prefixes. It might be nice to make the UI work more like the AbcExport UI for attributes eventually but I think we'd want to start using `frameLayout`s to keep things tidy, which would require translating the QT ui file to MEL.