### PR TITLE
Fixed non-Maya builds

### DIFF
--- a/3DSMax/CMakeLists.txt
+++ b/3DSMax/CMakeLists.txt
@@ -71,7 +71,7 @@ SOURCE_GROUP("Source Files" FILES ${Sources})
 SOURCE_GROUP("Header Files" FILES ${Includes})
 SOURCE_GROUP("_Maxscripts" FILES ${Scripts})
 
-setup_precompiled_header( ${BASE_DIR} ${Sources} )
+setup_precompiled_header( ${BASE_DIR} Sources )
 
 
 IF( WIN32 )

--- a/Arnold/CMakeLists.txt
+++ b/Arnold/CMakeLists.txt
@@ -14,7 +14,7 @@ file(GLOB_RECURSE Includes ${BASE_DIR}/*.h)
 SOURCE_GROUP("Source Files" FILES ${Sources}) 
 SOURCE_GROUP("Header Files" FILES ${Includes})
 
-setup_precompiled_header( ${BASE_DIR} ${Sources} )
+setup_precompiled_header( ${BASE_DIR} Sources )
 
 
 if( WIN32 )

--- a/Python/CMakeLists.txt
+++ b/Python/CMakeLists.txt
@@ -18,7 +18,7 @@ file(GLOB Includes ${BASE_DIR}/*.h)
 SOURCE_GROUP("Source Files" FILES ${Sources})
 SOURCE_GROUP("Header Files" FILES ${Includes})
 
-setup_precompiled_header( ${BASE_DIR} ${Sources} )
+setup_precompiled_header( ${BASE_DIR} Sources )
 
 
 LINK_LIBRARIES( CommonUtils

--- a/Softimage/CMakeLists.txt
+++ b/Softimage/CMakeLists.txt
@@ -24,7 +24,7 @@ file(GLOB Includes ${BASE_DIR}/*.h)
 SOURCE_GROUP("Source Files" FILES ${Sources})
 SOURCE_GROUP("Header Files" FILES ${Includes})
  
-setup_precompiled_header( ${BASE_DIR} ${Sources} )
+setup_precompiled_header( ${BASE_DIR} Sources )
 
 IF( WIN32 )
 	IF( ${ALEMBIC64} )


### PR DESCRIPTION
 I changed how `setup_precompiled_headers` worked in 4fd6f80 but forgot to update the other CMakeLists.txt files.