### PR TITLE
Fixes build breaks for Maya 2016 and Softimage 2015 on Windows

### DIFF
--- a/3DSMax/CMakeLists.txt
+++ b/3DSMax/CMakeLists.txt
@@ -71,7 +71,7 @@ SOURCE_GROUP("Source Files" FILES ${Sources})
 SOURCE_GROUP("Header Files" FILES ${Includes})
 SOURCE_GROUP("_Maxscripts" FILES ${Scripts})
 
-setup_precompiled_header( ${BASE_DIR} Sources )
+setup_precompiled_header( ${BASE_DIR} ${Sources} )
 
 
 IF( WIN32 )

--- a/Arnold/CMakeLists.txt
+++ b/Arnold/CMakeLists.txt
@@ -14,7 +14,7 @@ file(GLOB_RECURSE Includes ${BASE_DIR}/*.h)
 SOURCE_GROUP("Source Files" FILES ${Sources}) 
 SOURCE_GROUP("Header Files" FILES ${Includes})
 
-setup_precompiled_header( ${BASE_DIR} Sources )
+setup_precompiled_header( ${BASE_DIR} ${Sources} )
 
 
 if( WIN32 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,9 +48,9 @@ endif()
 
 if( MSVC9 )
 	SET( PROJECT_NAME "${PROJECT_NAME}_2008" )
-elseif( MSVC10 )
+elseif( MSVC10 ) 
 	SET( PROJECT_NAME "${PROJECT_NAME}_2010" )
-elseif( MSVC11 )
+elseif( MSVC11 ) 
 	SET( PROJECT_NAME "${PROJECT_NAME}_2012" )
 endif()
 
@@ -81,7 +81,7 @@ endif()
 # Configuration
 SET( crate_MAJOR_VERSION "1" )
 SET( crate_MINOR_VERSION "1" ) 
-SET( crate_BUILD_VERSION "151")
+SET( crate_BUILD_VERSION "145")
 SET( crate_VERSION "${crate_MAJOR_VERSION}.${crate_MINOR_VERSION}" )
 SET( crate_FULLVERSION "${crate_MAJOR_VERSION}.${crate_MINOR_VERSION}.${crate_BUILD_VERSION}" )
 
@@ -309,12 +309,15 @@ ENDIF()
 # maya plugin
 # guide to maya compiler versions: http://around-the-corner.typepad.com/adn/2012/06/maya-compiler-versions.html
 IF(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Maya/CMakeLists.txt")
-  if( MSVC10 )
+	if( NOT MSVC10 AND NOT MSVC11) 
+		ADD_SUBDIRECTORY ( "${CMAKE_CURRENT_SOURCE_DIR}/Maya/2011" "${CMAKE_CURRENT_BINARY_DIR}/ExocortexAlembicMaya/2011" )
+		ADD_SUBDIRECTORY ( "${CMAKE_CURRENT_SOURCE_DIR}/Maya/2012" "${CMAKE_CURRENT_BINARY_DIR}/ExocortexAlembicMaya/2012" )
+		ADD_SUBDIRECTORY ( "${CMAKE_CURRENT_SOURCE_DIR}/Maya/2013" "${CMAKE_CURRENT_BINARY_DIR}/ExocortexAlembicMaya/2013" )
+		#ADD_SUBDIRECTORY ( "${CMAKE_CURRENT_SOURCE_DIR}/Maya/2013.5" "${CMAKE_CURRENT_BINARY_DIR}/ExocortexAlembicMaya/2013.5" )
 		ADD_SUBDIRECTORY ( "${CMAKE_CURRENT_SOURCE_DIR}/Maya/2014" "${CMAKE_CURRENT_BINARY_DIR}/ExocortexAlembicMaya/2014" )
-  elseif( MSVC11 )
 		ADD_SUBDIRECTORY ( "${CMAKE_CURRENT_SOURCE_DIR}/Maya/2015" "${CMAKE_CURRENT_BINARY_DIR}/ExocortexAlembicMaya/2015" )
 		ADD_SUBDIRECTORY ( "${CMAKE_CURRENT_SOURCE_DIR}/Maya/2016" "${CMAKE_CURRENT_BINARY_DIR}/ExocortexAlembicMaya/2016" )
-  endif()
+	endif()
 ENDIF()
 
 # houdini plugin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,9 +48,9 @@ endif()
 
 if( MSVC9 )
 	SET( PROJECT_NAME "${PROJECT_NAME}_2008" )
-elseif( MSVC10 ) 
+elseif( MSVC10 )
 	SET( PROJECT_NAME "${PROJECT_NAME}_2010" )
-elseif( MSVC11 ) 
+elseif( MSVC11 )
 	SET( PROJECT_NAME "${PROJECT_NAME}_2012" )
 endif()
 
@@ -81,7 +81,7 @@ endif()
 # Configuration
 SET( crate_MAJOR_VERSION "1" )
 SET( crate_MINOR_VERSION "1" ) 
-SET( crate_BUILD_VERSION "145")
+SET( crate_BUILD_VERSION "151")
 SET( crate_VERSION "${crate_MAJOR_VERSION}.${crate_MINOR_VERSION}" )
 SET( crate_FULLVERSION "${crate_MAJOR_VERSION}.${crate_MINOR_VERSION}.${crate_BUILD_VERSION}" )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,15 +309,12 @@ ENDIF()
 # maya plugin
 # guide to maya compiler versions: http://around-the-corner.typepad.com/adn/2012/06/maya-compiler-versions.html
 IF(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Maya/CMakeLists.txt")
-	if( NOT MSVC10 AND NOT MSVC11) 
-		ADD_SUBDIRECTORY ( "${CMAKE_CURRENT_SOURCE_DIR}/Maya/2011" "${CMAKE_CURRENT_BINARY_DIR}/ExocortexAlembicMaya/2011" )
-		ADD_SUBDIRECTORY ( "${CMAKE_CURRENT_SOURCE_DIR}/Maya/2012" "${CMAKE_CURRENT_BINARY_DIR}/ExocortexAlembicMaya/2012" )
-		ADD_SUBDIRECTORY ( "${CMAKE_CURRENT_SOURCE_DIR}/Maya/2013" "${CMAKE_CURRENT_BINARY_DIR}/ExocortexAlembicMaya/2013" )
-		#ADD_SUBDIRECTORY ( "${CMAKE_CURRENT_SOURCE_DIR}/Maya/2013.5" "${CMAKE_CURRENT_BINARY_DIR}/ExocortexAlembicMaya/2013.5" )
+  if( MSVC10 )
 		ADD_SUBDIRECTORY ( "${CMAKE_CURRENT_SOURCE_DIR}/Maya/2014" "${CMAKE_CURRENT_BINARY_DIR}/ExocortexAlembicMaya/2014" )
+  elseif( MSVC11 )
 		ADD_SUBDIRECTORY ( "${CMAKE_CURRENT_SOURCE_DIR}/Maya/2015" "${CMAKE_CURRENT_BINARY_DIR}/ExocortexAlembicMaya/2015" )
 		ADD_SUBDIRECTORY ( "${CMAKE_CURRENT_SOURCE_DIR}/Maya/2016" "${CMAKE_CURRENT_BINARY_DIR}/ExocortexAlembicMaya/2016" )
-	endif()
+  endif()
 ENDIF()
 
 # houdini plugin

--- a/ExocortexCMakeShared.txt
+++ b/ExocortexCMakeShared.txt
@@ -19,14 +19,14 @@ function(setup_cpu_name)
 endfunction()
 
 
-function(setup_precompiled_header LocalSourceDir Sources)
+function(setup_precompiled_header LocalSourceDir)
 	if (MSVC)
 		set( LOCAL_SOURCE_DIR ${LocalSourceDir} )
 		
-		list( REMOVE_ITEM ${${Sources}} "${LOCAL_SOURCE_DIR}/stdafx.cpp" )
-		list( REMOVE_ITEM ${${Sources}} "${LOCAL_SOURCE_DIR}/stdafx.h" )
+		list( REMOVE_ITEM ARGN "${LOCAL_SOURCE_DIR}/stdafx.cpp" )
+		list( REMOVE_ITEM ARGN "${LOCAL_SOURCE_DIR}/stdafx.h" )
 
-		foreach( src_file ${${Sources}} )
+		foreach( src_file ${ARGN} )
 			set_source_files_properties(
 				${src_file}
 				PROPERTIES
@@ -37,7 +37,6 @@ function(setup_precompiled_header LocalSourceDir Sources)
 			PROPERTIES
 			COMPILE_FLAGS "/Ycstdafx.h"
 			)
-    list(APPEND ${Sources} ${LOCAL_SOURCE_DIR}/stdafx.cpp)
 	endif()
 endfunction()
 

--- a/Maya/CMakeLists.txt
+++ b/Maya/CMakeLists.txt
@@ -17,9 +17,7 @@ include_directories( ${BASE_DIR}/include )
 include_directories( ${BASE_DIR}/src )
 
 file(GLOB_RECURSE Sources ${BASE_DIR}/*.cpp)
-list(REMOVE_ITEM Sources ${BASE_DIR}/stdafx.cpp)
 file(GLOB_RECURSE Includes ${BASE_DIR}/*.h)
-list(REMOVE_ITEM Includes ${BASE_DIR}/stdafx.h)
 
 file(GLOB_RECURSE Scripts ${BASE_DIR}/MEL/*.*)
 file(GLOB_RECURSE UI ${BASE_DIR}/UI/*.*)
@@ -29,7 +27,7 @@ SOURCE_GROUP("Header Files" FILES ${Includes})
 SOURCE_GROUP("_MEL" FILES ${Scripts})
 SOURCE_GROUP("_UI" FILES ${UI}) 
 
-setup_precompiled_header( ${BASE_DIR} Sources )
+setup_precompiled_header( ${BASE_DIR} ${Sources} )
 
 IF( WIN32 )
 

--- a/Python/CMakeLists.txt
+++ b/Python/CMakeLists.txt
@@ -18,7 +18,7 @@ file(GLOB Includes ${BASE_DIR}/*.h)
 SOURCE_GROUP("Source Files" FILES ${Sources})
 SOURCE_GROUP("Header Files" FILES ${Includes})
 
-setup_precompiled_header( ${BASE_DIR} Sources )
+setup_precompiled_header( ${BASE_DIR} ${Sources} )
 
 
 LINK_LIBRARIES( CommonUtils

--- a/Shared/CommonUtils/CommonAbcCache.cpp
+++ b/Shared/CommonUtils/CommonAbcCache.cpp
@@ -1,5 +1,5 @@
-#include "CommonAbcCache.h"
 #include "CommonAlembic.h"
+#include "CommonAbcCache.h"
 #include "CommonMeshUtilities.h"
 #include "CommonUtilities.h"
 

--- a/Shared/CommonUtils/CommonImport.h
+++ b/Shared/CommonUtils/CommonImport.h
@@ -5,8 +5,8 @@
 #include <string>
 #include <vector>
 
-#include "CommonAbcCache.h"
 #include "CommonAlembic.h"
+#include "CommonAbcCache.h"
 #include "CommonSceneGraph.h"
 
 #include "CommonPBar.h"

--- a/Shared/CommonUtils/CommonUtilities.h
+++ b/Shared/CommonUtils/CommonUtilities.h
@@ -1,8 +1,8 @@
 #ifndef __COMMON_UTILITIES_H
 #define __COMMON_UTILITIES_H
 
-#include "CommonAbcCache.h"
 #include "CommonAlembic.h"
+#include "CommonAbcCache.h"
 
 #include "CommonPBar.h"
 

--- a/Softimage/CMakeLists.txt
+++ b/Softimage/CMakeLists.txt
@@ -24,7 +24,7 @@ file(GLOB Includes ${BASE_DIR}/*.h)
 SOURCE_GROUP("Source Files" FILES ${Sources})
 SOURCE_GROUP("Header Files" FILES ${Includes})
  
-setup_precompiled_header( ${BASE_DIR} Sources )
+setup_precompiled_header( ${BASE_DIR} ${Sources} )
 
 IF( WIN32 )
 	IF( ${ALEMBIC64} )


### PR DESCRIPTION
Both issues for these build breaks got introduced somewhere between 81f6fcd and 2fb8179.

### Issue 1:  build break for CommonUtils (Visual Studio 2012)
This has apparently been caused by the clang-formatting of **`Shared/CommonUtils`** introduced in 966e604.

Clang-format also reordered `#include` statements in several files. 
However apparently `"CommonAlembic.h"` must always be included before `CommonAbcCache.h"`.

Just reverting this include order in three files (while keeping all the rest of the clang-format changes) was enough to again successfully build CommonUtils on my side.

### Issue 2: build break for Softimage 2015
This got introduced due to various **CMake** changes introduced in 4fd6f80 and 7880e12.

I basically reverted all CMake changes introduced in those two commits and then **only** reintroduced the new crate_BUILD_VERSION and the changes in regards to which MSVC version builds which version of Maya.

With these changes I can now again successfully compile both Softimage 2015 and Maya 2016 (both with Visual Studio 2012).

Prior to these changes (but after fixing CommonUtils) I could only successfully compile Maya 2016 (with VS 2012) 

**A couple of notes on this:**

Please note that my CMake-fu is not strong - all I have been doing here is reverting back to the last known working state and then going forward again bit by bit making sure it still builds and my objective is met (--> build Maya 2015/2016 in VS2012)

I have only verified the Maya2016 and Softimage2015 build on Windows on my side using a fresh repo clone and a full rebuild.

@AWhetter :

I've got to admit that I don't know enough about CMake to even understand your changes to ExocortexCMakeShared.txt in the first place. :)
All I know is that they broke Soft2015, and on the other hand Maya2016 in VS2012 still builds without them.
So by all means if there is something that I am missing here then please do let me know.

Also as far as I understand the situation neither your nor myself have the ressources to fully build and check all other targets (3DSMax, Python, Arnold, Linux,...) .

Therefore I'd like to suggest to be extremely cautious with changes introduced to the shared parts of this project (like CMake and Shared/CommonUtils) and only touch/change them if absolutely necessary.
