### PR TITLE
Style fixes build fixes

### DIFF
--- a/3DSMax/CMakeLists.txt
+++ b/3DSMax/CMakeLists.txt
@@ -71,7 +71,7 @@ SOURCE_GROUP("Source Files" FILES ${Sources})
 SOURCE_GROUP("Header Files" FILES ${Includes})
 SOURCE_GROUP("_Maxscripts" FILES ${Scripts})
 
-setup_precompiled_header( ${BASE_DIR} Sources )
+setup_precompiled_header( ${BASE_DIR} ${Sources} )
 
 
 IF( WIN32 )

--- a/Arnold/CMakeLists.txt
+++ b/Arnold/CMakeLists.txt
@@ -14,7 +14,7 @@ file(GLOB_RECURSE Includes ${BASE_DIR}/*.h)
 SOURCE_GROUP("Source Files" FILES ${Sources}) 
 SOURCE_GROUP("Header Files" FILES ${Includes})
 
-setup_precompiled_header( ${BASE_DIR} Sources )
+setup_precompiled_header( ${BASE_DIR} ${Sources} )
 
 
 if( WIN32 )

--- a/ExocortexCMakeShared.txt
+++ b/ExocortexCMakeShared.txt
@@ -19,14 +19,14 @@ function(setup_cpu_name)
 endfunction()
 
 
-function(setup_precompiled_header LocalSourceDir Sources)
+function(setup_precompiled_header LocalSourceDir)
 	if (MSVC)
 		set( LOCAL_SOURCE_DIR ${LocalSourceDir} )
 		
-		list( REMOVE_ITEM ${${Sources}} "${LOCAL_SOURCE_DIR}/stdafx.cpp" )
-		list( REMOVE_ITEM ${${Sources}} "${LOCAL_SOURCE_DIR}/stdafx.h" )
+		list( REMOVE_ITEM ARGN "${LOCAL_SOURCE_DIR}/stdafx.cpp" )
+		list( REMOVE_ITEM ARGN "${LOCAL_SOURCE_DIR}/stdafx.h" )
 
-		foreach( src_file ${${Sources}} )
+		foreach( src_file ${ARGN} )
 			set_source_files_properties(
 				${src_file}
 				PROPERTIES
@@ -37,7 +37,6 @@ function(setup_precompiled_header LocalSourceDir Sources)
 			PROPERTIES
 			COMPILE_FLAGS "/Ycstdafx.h"
 			)
-    list(APPEND ${Sources} ${LOCAL_SOURCE_DIR}/stdafx.cpp)
 	endif()
 endfunction()
 

--- a/Maya/CMakeLists.txt
+++ b/Maya/CMakeLists.txt
@@ -17,9 +17,7 @@ include_directories( ${BASE_DIR}/include )
 include_directories( ${BASE_DIR}/src )
 
 file(GLOB_RECURSE Sources ${BASE_DIR}/*.cpp)
-list(REMOVE_ITEM Sources ${BASE_DIR}/stdafx.cpp)
 file(GLOB_RECURSE Includes ${BASE_DIR}/*.h)
-list(REMOVE_ITEM Includes ${BASE_DIR}/stdafx.h)
 
 file(GLOB_RECURSE Scripts ${BASE_DIR}/MEL/*.*)
 file(GLOB_RECURSE UI ${BASE_DIR}/UI/*.*)
@@ -29,7 +27,7 @@ SOURCE_GROUP("Header Files" FILES ${Includes})
 SOURCE_GROUP("_MEL" FILES ${Scripts})
 SOURCE_GROUP("_UI" FILES ${UI}) 
 
-setup_precompiled_header( ${BASE_DIR} Sources )
+setup_precompiled_header( ${BASE_DIR} ${Sources} )
 
 IF( WIN32 )
 

--- a/Python/CMakeLists.txt
+++ b/Python/CMakeLists.txt
@@ -18,7 +18,7 @@ file(GLOB Includes ${BASE_DIR}/*.h)
 SOURCE_GROUP("Source Files" FILES ${Sources})
 SOURCE_GROUP("Header Files" FILES ${Includes})
 
-setup_precompiled_header( ${BASE_DIR} Sources )
+setup_precompiled_header( ${BASE_DIR} ${Sources} )
 
 
 LINK_LIBRARIES( CommonUtils

--- a/Shared/CommonUtils/CommonAbcCache.h
+++ b/Shared/CommonUtils/CommonAbcCache.h
@@ -3,6 +3,7 @@
 
 #include <boost/smart_ptr.hpp>
 
+#include "CommonAlembic.h"
 #include "CommonPBar.h"
 
 typedef boost::shared_ptr<AbcG::IXform> IXformPtr;

--- a/Softimage/CMakeLists.txt
+++ b/Softimage/CMakeLists.txt
@@ -24,7 +24,7 @@ file(GLOB Includes ${BASE_DIR}/*.h)
 SOURCE_GROUP("Source Files" FILES ${Sources})
 SOURCE_GROUP("Header Files" FILES ${Includes})
  
-setup_precompiled_header( ${BASE_DIR} Sources )
+setup_precompiled_header( ${BASE_DIR} ${Sources} )
 
 IF( WIN32 )
 	IF( ${ALEMBIC64} )

--- a/Softimage/arnoldHelpers.h
+++ b/Softimage/arnoldHelpers.h
@@ -1,6 +1,8 @@
 #ifndef _ARNOLD_HELPERS_H_
 #define _ARNOLD_HELPERS_H_
 
+#include "stdafx.h"
+
 XSI::CStatus GetArnoldMotionBlurData(XSI::CDoubleArray &mbKeys, double frame);
 
 #endif


### PR DESCRIPTION
This is an alternative to #50 that fixes the build issues mentioned in #46.

The changes to `ExocortexCMakeShared.txt` were added originally because I was building with the "NMake Makefiles" generator instead of Visual Studio, and without the changes the stdafx precompiled header isn't generated. I think this is a CMake bug though so I've reverted the fix here and I'll post a bug to CMake.

I've also opted to add the missing includes to the `Shared/CommonUtils/CommonAbcCache.h` and `Softimage/arnoldHelpers.h` rather than just reorder the includes.

I did also have issues building 3DSMax but unrelated to the style fixes. They were because I was building with Visual Studio Express instead of Pro, so I haven't included those changes. If anyone is looking for a fix though I replaced "afxres.h" with "windows.h" in 3DSMax/Alembic.rc and added
```C
#ifndef IDC_STATIC
#define IDC_STATIC -1
#endif
```
to `3DSMax/resource.h`