### PR TITLE
Particle export from PhoenixFD for 3ds max

### DIFF
--- a/3DSMax/AlembicPoints.cpp
+++ b/3DSMax/AlembicPoints.cpp
@@ -571,6 +571,9 @@ Abc::C4f AlembicPoints::GetColor(IParticleObjectExt *pExt, int particleId,
   }
 
   IParticleGroup *particleGroup = GetParticleGroupInterface(particleGroupObj);
+  if (!particleGroup) {
+    return color;
+  }
   INode *particleActionListNode = particleGroup->GetActionList();
   Object *particleActionObj =
       (particleActionListNode != NULL
@@ -836,6 +839,10 @@ void AlembicPoints::GetShapeType(IParticleObjectExt *pExt, int particleId,
   }
 
   IParticleGroup *particleGroup = GetParticleGroupInterface(particleGroupObj);
+  if (!particleGroup) {
+    return;
+  }
+  
   INode *particleActionListNode = particleGroup->GetActionList();
   Object *particleActionObj =
       (particleActionListNode != NULL

--- a/3DSMax/AlembicPoints.cpp
+++ b/3DSMax/AlembicPoints.cpp
@@ -311,7 +311,7 @@ bool AlembicPoints::Save(double time, bool bLastFrame)
       }
       else
 #endif
-          if (particlesExt && ipfSystem) {
+      if (particlesExt) {
 
         TimeValue ageValue = particlesExt->GetParticleAgeByIndex(i);
         if (ageValue == -1) {


### PR DESCRIPTION
If not Thinking Particles, there is no need to check for both the ext particle interface and ipfSystem - in PhoenixFD we had to create a dummy PFSystem in order to workaround this limitation. The actual ipfSystem is checked before actually being used about 20 lines further.

Also, the built-in 3ds max Alembic export forces us to provide a dummy node as a result of GetParticleGroup() in order for the export to proceed correctly. This is why the returned node does not have to necessarily implement the IParticleGroup interface and should better be checked against NULL.
